### PR TITLE
Add system logging with web UI access

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -35,7 +35,8 @@
 
 <p>
   <a href="config.html">Configurer le système</a> |
-  <a href="example.html">Exemple de mesure de puissance</a>
+  <a href="example.html">Exemple de mesure de puissance</a> |
+  <a href="logs.html">Logs système</a>
 </p>
 
 <script>

--- a/data/logs.html
+++ b/data/logs.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Logs MiniLabBox</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; }
+    pre { background: #f0f0f0; padding: 1em; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+<h1>Logs du système</h1>
+<pre id="log">Chargement...</pre>
+<script>
+async function loadLogs() {
+  try {
+    const resp = await fetch('/api/logs');
+    if (!resp.ok) {
+      document.getElementById('log').textContent = 'Impossible de charger les logs';
+      return;
+    }
+    const text = await resp.text();
+    document.getElementById('log').textContent = text;
+  } catch (err) {
+    document.getElementById('log').textContent = 'Erreur de chargement';
+  }
+}
+window.addEventListener('DOMContentLoaded', loadLogs);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add LittleFS-backed logging system and route logs to web UI
- log key events like configuration load/save and Wi-Fi setup
- create simple logs.html page and link from index

## Testing
- `pio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68c73a687044832e90b78d8ef68cb360