### PR TITLE
Fix missing Update header

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@
 #include <Adafruit_ADS1015.h>
 #include <ESP8266mDNS.h>
 #include <U8g2lib.h>
-#include <Update.h>
+#include <Updater.h>
 
 static const char *FIRMWARE_VERSION = "1.0.0";
 


### PR DESCRIPTION
## Summary
- include Updater.h instead of Update.h for ESP8266 builds

## Testing
- ❌ `pio run` *(command not found and platformio could not be installed: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7429e8364832e95de9cdce08df0bf