### PR TITLE
Ensure I2C init for OLED and fix config save request

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -373,7 +373,10 @@ async function saveConfig() {
   try {
     const resp = await fetch('/api/config/set', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      // The firmware expects a plain text body for configuration updates.
+      // Sending JSON with a text/plain content type allows the server to
+      // access the payload via the "plain" parameter.
+      headers: { 'Content-Type': 'text/plain' },
       body: JSON.stringify(cfg)
     });
     if (resp.ok) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,10 @@ static String oledLines[OLED_MAX_LINES];
 static bool oledLogging = true;
 
 static void initOled() {
+  // Ensure the I2C bus is initialised before interacting with the OLED.
+  // Some libraries implicitly call Wire.begin(), but doing it explicitly
+  // here avoids a blank display on boards where it is not started yet.
+  Wire.begin();
   oled.begin();
   oled.clearBuffer();
   oled.setFont(u8g2_font_5x7_tf);


### PR DESCRIPTION
## Summary
- Initialize I2C bus before using the OLED to avoid blank displays
- Send configuration updates as plain text JSON so the firmware can read the body

## Testing
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c748a93ad8832ea0923e789ff13619