### PR TITLE
Fix resolveUserPath prefix handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,14 +52,14 @@ static bool resolveUserPath(const String &clientPath, String &fsPath) {
   if (clientPath.length() == 0) return false;
   String cleaned = clientPath;
   cleaned.replace('\\', '/');
-  while (cleaned.startsWith('/')) {
+  while (cleaned.startsWith("/")) {
     cleaned.remove(0, 1);
   }
   cleaned.trim();
   if (cleaned.length() == 0) return false;
   if (cleaned.indexOf("//") != -1) return false;
   int start = 0;
-  while (start < cleaned.length()) {
+  while (start < static_cast<int>(cleaned.length())) {
     int sep = cleaned.indexOf('/', start);
     int end = (sep == -1) ? cleaned.length() : sep;
     String segment = cleaned.substring(start, end);


### PR DESCRIPTION
## Summary
- fix resolveUserPath to call startsWith with a string literal so the Arduino String overload is selected
- cast the String length comparison to avoid signed/unsigned warnings during compilation

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86e810028832eb54ec4c085b2a3d0