### PR TITLE
Handle builds without AsyncTCP TLS support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,5 +27,4 @@ lib_compat_mode = strict
 build_flags =
   -DASYNCWEBSERVER_REGEX
   -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-  -DASYNC_TCP_SSL_ENABLED
   -Isrc


### PR DESCRIPTION
## Summary
- guard TLS assets and secure server startup behind `ASYNC_TCP_SSL_ENABLED`
- add a wrapper so `beginSecure` works with void or bool return types
- fall back to a plain HTTP server and advertise the correct services when TLS is unavailable
- drop the AsyncTCP SSL build flag so the build no longer requires the missing axTLS headers

## Testing
- not run (platformio unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8993ed7f8832e9ba4831300d87ef6