### PR TITLE
Fix session cookie on HTTP deployments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -966,7 +966,9 @@ String buildSessionCookie(const String &value, bool expire) {
     cookie += "; Max-Age=0";
   }
   cookie += "; HttpOnly";
-  cookie += "; Secure";
+  if (HAS_SECURE_SERVER) {
+    cookie += "; Secure";
+  }
   cookie += "; SameSite=Strict";
   return cookie;
 }


### PR DESCRIPTION
## Summary
- avoid setting the Secure attribute on session cookies when the firmware is running without TLS

## Testing
- not run (platformio/`pio` command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c93527d3f0832e9b7f2c4b91d75bd2