### PR TITLE
Disable AsyncTCP SSL define to prevent missing axTLS header

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,8 +24,12 @@ lib_deps =
 lib_ldf_mode = chain+
 lib_compat_mode = strict
 
+; TLS in ESPAsyncWebServer relies on the legacy axTLS headers (include/ssl.h)
+; that are no longer shipped with recent ESP8266 Arduino cores.  Leaving
+; ASYNC_TCP_SSL_ENABLED undefined avoids the missing include error while keeping
+; the firmware functional over HTTP.  Define ASYNC_TCP_SSL_ENABLED manually if
+; you have a toolchain that still provides axTLS.
 build_flags =
   -DASYNCWEBSERVER_REGEX
-  -DASYNC_TCP_SSL_ENABLED
   -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
   -Isrc


### PR DESCRIPTION
## Summary
- stop defining `ASYNC_TCP_SSL_ENABLED` in the default build flags so ESPAsyncTCP no longer requires the legacy axTLS headers
- document in `platformio.ini` how to re-enable TLS only when the appropriate SDK with `include/ssl.h` is available

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c9e1a70832e8e560bb58aa1d333