### PR TITLE
Add HTTPS support using ESP8266 secure web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # minilabo
-Low tech elec labo
+
+Low tech elec labo firmware for the ESP8266 based MiniLabBox. The web
+interface is now served over HTTPS using an embedded self-signed
+certificate; connect to `https://<node-id>.local` (or the device IP) and
+accept the certificate warning in your browser.

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,16 +7,10 @@ framework = arduino
 board_build.filesystem = littlefs
 monitor_speed = 115200
 
-; Avoid pulling in the wrong AsyncTCP variants
-lib_ignore = AsyncTCP, AsyncTCP_RP2040W
-
-; External dependencies.  ESPAsyncWebServer provides the HTTP stack.  
-; ESPAsyncTCP is required by the web server.  ArduinoJson handles configuration
-; and API responses.  U8g2 is included for potential OLED support.  
-; Adafruit ADS1X15 supplies the driver for the optional ADS1115 ADC module.
+; External dependencies.  ArduinoJson handles configuration and API
+; responses.  U8g2 is included for optional OLED support.  Adafruit
+; ADS1X15 supplies the driver for the optional ADS1115 ADC module.
 lib_deps =
-  https://github.com/me-no-dev/ESPAsyncWebServer.git
-  https://github.com/me-no-dev/ESPAsyncTCP.git
   bblanchon/ArduinoJson@^6.21.5
   olikraus/U8g2@^2.36.12
   adafruit/Adafruit ADS1X15@^1.1.2
@@ -24,12 +18,6 @@ lib_deps =
 lib_ldf_mode = chain+
 lib_compat_mode = strict
 
-; TLS in ESPAsyncWebServer relies on the legacy axTLS headers (include/ssl.h)
-; that are no longer shipped with recent ESP8266 Arduino cores.  Leaving
-; ASYNC_TCP_SSL_ENABLED undefined avoids the missing include error while keeping
-; the firmware functional over HTTP.  Define ASYNC_TCP_SSL_ENABLED manually if
-; you have a toolchain that still provides axTLS.
 build_flags =
-  -DASYNCWEBSERVER_REGEX
   -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
   -Isrc


### PR DESCRIPTION
## Summary
- replace the Async web server stack with ESP8266WebServerSecure plus an HTTP redirector so the firmware serves the UI over HTTPS
- rewrite the REST handlers to run on the synchronous server, update cookie handling, and keep the servers serviced in loop()
- trim Async-specific dependencies from platformio.ini and document HTTPS access in the README

## Testing
- `pio run` *(fails: PlatformIO is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c972ed895c832e9cca8c4705e21da7