### PR TITLE
Enable concurrent HTTP and HTTPS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # minilabo
 
 Low tech elec labo firmware for the ESP8266 based MiniLabBox. The web
-interface is now served over HTTPS using an embedded self-signed
+interface is served over HTTPS using an embedded self-signed
 certificate; connect to `https://<node-id>.local` (or the device IP) and
-accept the certificate warning in your browser.
+accept the certificate warning in your browser. A plain HTTP endpoint on
+port 80 remains available for legacy clients while HTTPS is preferred.


### PR DESCRIPTION
## Summary
- serve the full MiniLabBox interface over both HTTPS and plain HTTP so the UI stays accessible when TLS handshakes fail
- adjust session cookie handling to only mark cookies as Secure on TLS responses and tidy server startup logging
- document the optional HTTP access path in the README for clarity

## Testing
- `pio run` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c2e5104832e957f5025306e63e6