### PR TITLE
Fix OTA update error handling for ESP8266

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -366,7 +366,7 @@ static String otaLastError;
 
 static String otaErrorMessage() {
 #if defined(ARDUINO_ARCH_ESP8266)
-  return Update.errorString();
+  return Update.getErrorString();
 #else
   return String("update_error");
 #endif
@@ -1644,7 +1644,7 @@ void registerRoutes(ServerT &server) {
                         static_cast<unsigned>(otaUploadSize),
                         otaLastError.c_str());
               Update.printError(Serial);
-              Update.abort();
+              Update.end();
             } else {
               otaUploadSize = upload.totalSize;
             }
@@ -1677,7 +1677,7 @@ void registerRoutes(ServerT &server) {
             otaLastError = "aborted";
             logMessage("OTA upload aborted by client");
             if (Update.isRunning()) {
-              Update.abort();
+              Update.end();
             }
             break;
           }


### PR DESCRIPTION
## Summary
- replace deprecated Updater API calls to match current ESP8266 SDK
- use Update.getErrorString() and Update.end() during OTA uploads

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7845a3bc832ea3e5d727f438f720