### PR TITLE
Fix OTA upload via web UI and improve logging

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -597,13 +597,31 @@ window.addEventListener('DOMContentLoaded', () => {
     const file = document.getElementById('fwFile').files[0];
     const st = document.getElementById('fwStatus');
     if (!file) { st.textContent = 'Choisir un fichier'; return; }
+    const formData = new FormData();
+    formData.append('firmware', file, file.name);
     st.textContent = 'Téléversement...';
     try {
-      const resp = await authFetch('/api/ota', {method: 'POST', body: file});
+      const resp = await authFetch('/api/ota', {method: 'POST', body: formData});
       if (resp.ok) {
         st.textContent = 'Mise à jour envoyée, redémarrage...';
       } else {
-        st.textContent = 'Échec de la mise à jour';
+        let message = 'Échec de la mise à jour';
+        try {
+          const data = await resp.clone().json();
+          if (data && data.error) {
+            message = `Échec de la mise à jour (${data.error})`;
+          }
+        } catch (jsonErr) {
+          try {
+            const text = await resp.text();
+            if (text) {
+              message = `Échec de la mise à jour (${text})`;
+            }
+          } catch (_) {
+            // Ignore text parsing errors
+          }
+        }
+        st.textContent = message;
       }
     } catch (err) {
       st.textContent = 'Erreur de mise à jour';

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1579,6 +1579,7 @@ void registerRoutes(ServerT &server) {
           return;
         }
         if (!otaUploadInProgress) {
+          logMessage("OTA finalize requested but no upload in progress");
           srv->send(400, "application/json", R"({"error":"no_upload"})");
           return;
         }


### PR DESCRIPTION
## Summary
- send firmware uploads as multipart/form-data from the configuration page so the OTA handler receives the binary
- surface OTA error details in the UI and log finalize calls without an active upload for easier diagnosis

## Testing
- ⚠️ `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8278ceb4832ea8e8646de76d6153