### PR TITLE
Fix LittleFS config persistence and compile-time firmware version

### DIFF
--- a/src/build_version.h
+++ b/src/build_version.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace BuildInfo {
+// Increment this value with each firmware commit pushed to Git.
+constexpr std::uint32_t kFirmwarePatch = 5;
+}
+


### PR DESCRIPTION
## Summary
- add a build_version header so the firmware patch is tied to repository commits rather than device boots
- initialise the firmware version string from the build info and remove the on-device counter
- centralise LittleFS mounting logic to avoid unintended formatting and keep I/O configuration files across reboots

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caac0757a0832e94d3a05faaec8263