### PR TITLE
Update dashboard to reflect configured IO

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -42,13 +42,161 @@
 </p>
 
 <script>
-// Récupère la configuration pour afficher l'identifiant du nœud
+let configuredInputs = [];
+let configuredOutputs = [];
+const inputRowMap = new Map();
+const outputRowMap = new Map();
+
+function normaliseNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const num = typeof value === 'number' ? value : parseFloat(value);
+  if (!Number.isFinite(num)) {
+    return null;
+  }
+  return num;
+}
+
+function formatDisplayValue(value) {
+  const num = normaliseNumber(value);
+  return num === null ? '—' : num.toFixed(3);
+}
+
+function renderEmptyRow(tbody, message, colspan) {
+  const row = document.createElement('tr');
+  row.classList.add('empty-row');
+  const cell = document.createElement('td');
+  cell.colSpan = colspan;
+  cell.textContent = message;
+  row.appendChild(cell);
+  tbody.appendChild(row);
+}
+
+function normaliseConfiguredInput(item) {
+  if (!item) return null;
+  const name = (item.name || '').toString();
+  if (!name) return null;
+  const type = (item.type || '').toString().toLowerCase();
+  const unit = item.unit ? item.unit.toString() : '';
+  const active = !!item.active && type !== 'disabled';
+  return { name, unit, active };
+}
+
+function normaliseConfiguredOutput(item) {
+  if (!item) return null;
+  const name = (item.name || '').toString();
+  if (!name) return null;
+  const type = (item.type || '').toString().toLowerCase();
+  const active = !!item.active && type !== 'disabled';
+  const value = normaliseNumber(item.value);
+  return { name, active, value };
+}
+
+function renderConfiguredInputs() {
+  const tbody = document.querySelector('#inputsTable tbody');
+  if (!tbody) return;
+  inputRowMap.clear();
+  tbody.innerHTML = '';
+  const activeInputs = configuredInputs.filter(item => item && item.active);
+  if (activeInputs.length === 0) {
+    renderEmptyRow(tbody, 'Aucune entrée active.', 3);
+    return;
+  }
+  activeInputs.forEach(item => {
+    const tr = document.createElement('tr');
+    tr.dataset.name = item.name;
+    const tdName = document.createElement('td');
+    tdName.textContent = item.name;
+    const tdVal = document.createElement('td');
+    tdVal.textContent = '—';
+    const tdUnit = document.createElement('td');
+    tdUnit.textContent = item.unit || '';
+    const rowInfo = {
+      valueCell: tdVal,
+      unitCell: tdUnit,
+      defaultUnit: item.unit || ''
+    };
+    tr.appendChild(tdName);
+    tr.appendChild(tdVal);
+    tr.appendChild(tdUnit);
+    tbody.appendChild(tr);
+    inputRowMap.set(item.name, rowInfo);
+  });
+}
+
+function renderConfiguredOutputs() {
+  const tbody = document.querySelector('#outputsTable tbody');
+  if (!tbody) return;
+  outputRowMap.clear();
+  tbody.innerHTML = '';
+  const activeOutputs = configuredOutputs.filter(item => item && item.active);
+  if (activeOutputs.length === 0) {
+    renderEmptyRow(tbody, 'Aucune sortie active.', 3);
+    return;
+  }
+  activeOutputs.forEach(item => {
+    const tr = document.createElement('tr');
+    tr.dataset.name = item.name;
+    const tdName = document.createElement('td');
+    tdName.textContent = item.name;
+    const tdVal = document.createElement('td');
+    tdVal.textContent = formatDisplayValue(item.value);
+    const tdSet = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0.1';
+    const initialValue = item.value;
+    if (initialValue !== null) {
+      input.value = initialValue;
+    } else {
+      input.value = '';
+    }
+    const rowInfo = {
+      valueCell: tdVal,
+      inputEl: input,
+      lastValue: initialValue
+    };
+    input.addEventListener('change', () => {
+      const numeric = normaliseNumber(input.value);
+      if (numeric === null) {
+        if (rowInfo.lastValue !== null) {
+          input.value = rowInfo.lastValue;
+        } else {
+          input.value = '';
+        }
+        return;
+      }
+      rowInfo.lastValue = numeric;
+      setOutput(item.name, numeric);
+    });
+    tdSet.appendChild(input);
+    tr.appendChild(tdName);
+    tr.appendChild(tdVal);
+    tr.appendChild(tdSet);
+    tbody.appendChild(tr);
+    outputRowMap.set(item.name, rowInfo);
+  });
+}
+
+// Récupère la configuration pour afficher l'identifiant du nœud et préparer les tables
 async function loadConfig() {
   try {
     const resp = await authFetch('/api/config/get');
     if (!resp.ok) return;
     const cfg = await resp.json();
-    document.getElementById('nodeId').innerText = cfg.nodeId || '';
+    const nodeEl = document.getElementById('nodeId');
+    if (nodeEl) {
+      nodeEl.innerText = cfg.nodeId || '';
+    }
+    configuredInputs = Array.isArray(cfg.inputs)
+      ? cfg.inputs.map(normaliseConfiguredInput).filter(Boolean)
+      : [];
+    configuredOutputs = Array.isArray(cfg.outputs)
+      ? cfg.outputs.map(normaliseConfiguredOutput).filter(Boolean)
+      : [];
+    renderConfiguredInputs();
+    renderConfiguredOutputs();
   } catch (err) {
     console.error(err);
   }
@@ -57,50 +205,48 @@ async function loadConfig() {
 // Rafraîchit les valeurs des entrées et sorties
 async function loadValues() {
   try {
-    const inResp = await authFetch('/api/inputs');
-    const inputs = await inResp.json();
-    const inputsTBody = document.querySelector('#inputsTable tbody');
-    inputsTBody.innerHTML = '';
-    Object.keys(inputs).forEach(name => {
-      const tr = document.createElement('tr');
-      const tdName = document.createElement('td');
-      tdName.textContent = name;
-      const tdVal = document.createElement('td');
-      const val = inputs[name];
-      if (val === null || isNaN(val)) tdVal.textContent = '—';
-      else tdVal.textContent = Number(val).toFixed(3);
-      const tdUnit = document.createElement('td');
-      tdUnit.textContent = '';
-      tr.appendChild(tdName);
-      tr.appendChild(tdVal);
-      tr.appendChild(tdUnit);
-      inputsTBody.appendChild(tr);
-    });
-    const outResp = await authFetch('/api/outputs');
-    const outputs = await outResp.json();
-    const outputsTBody = document.querySelector('#outputsTable tbody');
-    outputsTBody.innerHTML = '';
-    Object.keys(outputs).forEach(name => {
-      const tr = document.createElement('tr');
-      const tdName = document.createElement('td');
-      tdName.textContent = name;
-      const tdVal = document.createElement('td');
-      const val = outputs[name];
-      if (val === null || isNaN(val)) tdVal.textContent = '—';
-      else tdVal.textContent = Number(val).toFixed(3);
-      const tdSet = document.createElement('td');
-      const inp = document.createElement('input');
-      inp.type = 'number';
-      inp.step = '0.1';
-      inp.value = val;
-      inp.id = 'out_' + name;
-      inp.addEventListener('change', () => setOutput(name, parseFloat(inp.value)));
-      tdSet.appendChild(inp);
-      tr.appendChild(tdName);
-      tr.appendChild(tdVal);
-      tr.appendChild(tdSet);
-      outputsTBody.appendChild(tr);
-    });
+    const [inResp, outResp] = await Promise.all([
+      authFetch('/api/inputs'),
+      authFetch('/api/outputs')
+    ]);
+    if (inResp.ok) {
+      const data = await inResp.json();
+      const list = Array.isArray(data.inputs) ? data.inputs : [];
+      inputRowMap.forEach(info => {
+        info.valueCell.textContent = '—';
+        info.unitCell.textContent = info.defaultUnit || '';
+      });
+      list.forEach(item => {
+        if (!item || !item.name) return;
+        const rowInfo = inputRowMap.get(item.name);
+        if (!rowInfo) return;
+        rowInfo.valueCell.textContent = formatDisplayValue(item.value);
+        const unit = (typeof item.unit === 'string' && item.unit.length > 0)
+          ? item.unit
+          : rowInfo.defaultUnit || '';
+        rowInfo.unitCell.textContent = unit;
+      });
+    }
+    if (outResp.ok) {
+      const data = await outResp.json();
+      const list = Array.isArray(data.outputs) ? data.outputs : [];
+      list.forEach(item => {
+        if (!item || !item.name) return;
+        const rowInfo = outputRowMap.get(item.name);
+        if (!rowInfo) return;
+        rowInfo.valueCell.textContent = formatDisplayValue(item.value);
+        const numeric = normaliseNumber(item.value);
+        if (numeric !== null) {
+          rowInfo.inputEl.value = numeric;
+          rowInfo.lastValue = numeric;
+        }
+        if (item.active === false) {
+          rowInfo.inputEl.disabled = true;
+        } else {
+          rowInfo.inputEl.disabled = false;
+        }
+      });
+    }
   } catch (err) {
     console.error(err);
   }
@@ -117,9 +263,9 @@ function setOutput(name, value) {
 
 window.addEventListener('DOMContentLoaded', () => {
   ensureSession()
-    .then(() => {
-      loadConfig();
-      loadValues();
+    .then(async () => {
+      await loadConfig();
+      await loadValues();
       setInterval(loadValues, 1000);
     })
     .catch(err => {


### PR DESCRIPTION
## Summary
- load the configured inputs and outputs when the dashboard starts so the UI reflects registered channels
- build table rows from the stored configuration (including units) and keep them mapped for live updates
- refresh values from the API array payloads and keep output controls in sync with the latest readings

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68caafde73b0832e8991c7fdfd33bd71