### PR TITLE
Fix logMessage forward declaration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 #include "build_version.h"
 
 static void logPrintf(const char *fmt, ...);
+static void logMessage(const String &msg);
 
 static const uint8_t FIRMWARE_VERSION_MAJOR = 1;
 static const uint8_t FIRMWARE_VERSION_MINOR = 0;
@@ -85,7 +86,6 @@ static const char *getFirmwareVersion() {
 // ---------------------------------------------------------------------------
 static const char *LOG_PATH = "/log.txt";
 static const char *USER_FILES_DIR = "/private";
-static const char *SAMPLE_FILE_NAME = "sample.html";
 static const char *SAMPLE_FILE_PATH = "/private/sample.html";
 static const char *CONFIG_FILE_PATH = "/private/io_config.json";
 static const char *CONFIG_BACKUP_FILE_PATH = "/private/io_config.bak";


### PR DESCRIPTION
## Summary
- forward declare logMessage before its first use
- remove an unused sample file name constant

## Testing
- `pio run` *(fails: PlatformIO is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caeb781b78832e97e5c45433d1682f