### PR TITLE
Fix applying posted configuration updates

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2432,9 +2432,7 @@ void registerRoutes(ServerT &server) {
       return;
     }
     Config previousConfig = config;
-    Config updatedConfig = config;
-    parseConfigFromJson(doc, updatedConfig, &config, true);
-    config = updatedConfig;
+    parseConfigFromJson(doc, config, &previousConfig, true);
     if (!saveConfig()) {
       config = previousConfig;
       srv->send(500, "application/json", R"({"error":"save failed"})");


### PR DESCRIPTION
## Summary
- apply posted configuration updates directly to the active config while still keeping a previous snapshot for logging
- keep the prior configuration for rollback if saving the new settings fails

## Testing
- not run (embedded firmware)

------
https://chatgpt.com/codex/tasks/task_e_68cb1f32c20c832ea19a1a2b794b4e6c