### PR TITLE
Improve logging for configuration updates

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2445,13 +2445,19 @@ void registerRoutes(ServerT &server) {
       srv->send(400, "application/json", R"({"error":"Invalid JSON"})");
       return;
     }
+    logPrintf("Configuration update received (%u bytes)",
+              static_cast<unsigned>(body.length()));
+    logConfigJson("Received", doc);
     Config previousConfig = config;
     parseConfigFromJson(doc, config, &previousConfig, true);
     if (!saveConfig()) {
       config = previousConfig;
+      logMessage("Configuration update failed to save; changes reverted");
       srv->send(500, "application/json", R"({"error":"save failed"})");
       return;
     }
+    logConfigSummary("Applied");
+    logMessage("Configuration update saved; rebooting");
     srv->send(200, "application/json", R"({"status":"ok"})");
     delay(100);
     ESP.restart();


### PR DESCRIPTION
## Summary
- log incoming configuration payloads for /api/config/set requests with masked credentials
- add status messages covering save failures and the reboot path for configuration updates
- record applied configuration summary to clarify what was stored when saving succeeds

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb291ad45c832e98dbf3f469134593