### PR TITLE
Refine firmware versioning scheme

### DIFF
--- a/src/build_version.h
+++ b/src/build_version.h
@@ -3,7 +3,23 @@
 #include <cstdint>
 
 namespace BuildInfo {
-// Increment this value with each firmware commit pushed to Git.
+// Update these constants to reflect the current firmware semantic version.
+// Use MAJOR.MINOR.PATCH for released builds and optionally append
+// pre-release/build metadata tags (see RFC 9110 / Semantic Versioning 2.0.0).
+constexpr std::uint8_t kFirmwareMajor = 1;
+constexpr std::uint8_t kFirmwareMinor = 0;
 constexpr std::uint32_t kFirmwarePatch = 5;
+
+// Optional identifiers. Leave empty when not required.
+constexpr const char *kFirmwarePreReleaseTag = "";
+constexpr const char *kFirmwareBuildMetadata = "";
+
+inline bool HasPreReleaseTag() {
+  return kFirmwarePreReleaseTag != nullptr && kFirmwarePreReleaseTag[0] != '\0';
 }
+
+inline bool HasBuildMetadata() {
+  return kFirmwareBuildMetadata != nullptr && kFirmwareBuildMetadata[0] != '\0';
+}
+}  // namespace BuildInfo
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,18 +34,25 @@
 static void logPrintf(const char *fmt, ...);
 static void logMessage(const String &msg);
 
-static const uint8_t FIRMWARE_VERSION_MAJOR = 1;
-static const uint8_t FIRMWARE_VERSION_MINOR = 0;
 static bool logStorageReady = false;
 static bool littleFsFormatAttempted = false;
 static String firmwareVersion = "0.0.0";
 
-static String formatFirmwareVersion(uint32_t patch) {
-  char buf[24];
-  snprintf(buf, sizeof(buf), "%u.%u.%lu", static_cast<unsigned>(FIRMWARE_VERSION_MAJOR),
-           static_cast<unsigned>(FIRMWARE_VERSION_MINOR),
-           static_cast<unsigned long>(patch));
-  return String(buf);
+static String formatFirmwareVersion() {
+  String version = String(static_cast<unsigned>(BuildInfo::kFirmwareMajor));
+  version += ".";
+  version += String(static_cast<unsigned>(BuildInfo::kFirmwareMinor));
+  version += ".";
+  version += String(static_cast<unsigned long>(BuildInfo::kFirmwarePatch));
+  if (BuildInfo::HasPreReleaseTag()) {
+    version += "-";
+    version += BuildInfo::kFirmwarePreReleaseTag;
+  }
+  if (BuildInfo::HasBuildMetadata()) {
+    version += "+";
+    version += BuildInfo::kFirmwareBuildMetadata;
+  }
+  return version;
 }
 
 static bool ensureLittleFsReady(bool allowFormat = false) {
@@ -69,9 +76,11 @@ static bool ensureLittleFsReady(bool allowFormat = false) {
 }
 
 static void initFirmwareVersion() {
-  firmwareVersion = formatFirmwareVersion(BuildInfo::kFirmwarePatch);
-  logPrintf("Firmware version initialised to %s (build %lu)",
+  firmwareVersion = formatFirmwareVersion();
+  logPrintf("Firmware version initialised to %s (major=%u minor=%u patch=%lu)",
             firmwareVersion.c_str(),
+            static_cast<unsigned>(BuildInfo::kFirmwareMajor),
+            static_cast<unsigned>(BuildInfo::kFirmwareMinor),
             static_cast<unsigned long>(BuildInfo::kFirmwarePatch));
 }
 


### PR DESCRIPTION
## Summary
- move firmware version major, minor and patch numbers into build_version.h alongside optional pre-release/build metadata tags
- expose helpers to check for optional tags and use them when formatting the runtime firmware version string
- log the semantic version components during firmware initialisation for easier tracking

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb24064bc832e8a45dea5c457d3a3