### PR TITLE
Add IO guidance panel and example pages

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -58,6 +58,10 @@
     .modal-form-row select { width: 100%; box-sizing: border-box; }
     .modal-actions { display: flex; justify-content: flex-end; gap: 0.6em; margin-top: 1.2em; }
     .modal-description { font-size: 0.9em; color: #555; margin-bottom: 0.9em; }
+    .modal-info { background: #f2f6ff; border-left: 4px solid #3a6abf; padding: 0.75em 1em; border-radius: 6px; color: #2a3a55; font-size: 0.9em; margin-bottom: 1em; }
+    .modal-info h3 { margin: 0 0 0.35em; font-size: 1em; }
+    .modal-info ul { margin: 0.4em 0 0 1.2em; padding: 0; }
+    .modal-info li { margin-bottom: 0.3em; }
   </style>
   <script src="auth.js"></script>
 </head>
@@ -147,6 +151,7 @@
   <div class="modal-content">
     <h2 id="modalTitle">Configurer</h2>
     <p class="modal-description" id="modalDescription"></p>
+    <div class="modal-info" id="modalInfo" aria-live="polite"></div>
     <form id="modalForm">
       <div class="modal-form-row">
         <label for="modalName">Nom</label>
@@ -214,6 +219,184 @@ const MODULE_DEPENDENCIES = {
     mcp4725: 'mcp4725'
   }
 };
+
+const INPUT_TYPE_DETAILS = {
+  adc: {
+    title: 'Entrée ADC interne',
+    summary: 'Utilise le convertisseur analogique-numérique intégré de l’ESP8266 sur la broche A0.',
+    resolution: '10 bits (0 à 1023 codes bruts).',
+    rawRange: '0 à 1023 bits mesurés.',
+    physicalRange: '≈ 0 à 1,0 V sur A0 (atténuation intégrée).',
+    rawTagSuffix: '_bits',
+    notes: [
+      'Appliquez une échelle (ex. 0,001) pour convertir les bits en volts réels.',
+      'Le décalage compense un éventuel zéro non nul.'
+    ]
+  },
+  ads1115: {
+    title: 'Entrée ADS1115',
+    summary: 'Lit un canal simple du convertisseur ADS1115 externe configuré en gain ×1.',
+    resolution: '16 bits (0 à 32767 en mode simple).',
+    rawRange: '0 à 32767 codes.',
+    physicalRange: '0 à 4,096 V pour le gain par défaut.',
+    rawTagSuffix: '_bits',
+    notes: [
+      'Chaque code représente environ 125 µV. Ajustez l’échelle pour exprimer la tension en volts.',
+      'Assurez-vous d’avoir activé le module ADS1115 dans la configuration.'
+    ]
+  },
+  remote: {
+    title: 'Entrée distante',
+    summary: 'Récupère une mesure diffusée par un autre MiniLabBox via UDP sécurisé.',
+    notes: [
+      'La plage dépend du capteur distant ; aucune conversion matérielle locale n’est appliquée.',
+      'Saisissez exactement l’identifiant du nœud et le nom distant pour recevoir la valeur.'
+    ]
+  },
+  zmpt: {
+    title: 'Capteur de tension AC (ZMPT101B)',
+    summary: 'Calcule la valeur RMS de la composante AC mesurée par le module ZMPT101B.',
+    resolution: '10 bits (calcul RMS sur 32 échantillons).',
+    rawRange: '0 à ≈512 bits RMS autour de la valeur médiane.',
+    physicalRange: 'Plage proportionnelle à la tension AC après calibration.',
+    rawTagSuffix: '_bits',
+    notes: [
+      'La valeur brute correspond à l’écart autour de 512 (centre de l’ADC).',
+      'Calibrez l’échelle pour exprimer la tension efficace en volts.'
+    ]
+  },
+  zmct: {
+    title: 'Capteur de courant AC (ZMCT103C)',
+    summary: 'Mesure le courant AC RMS à l’aide du transformateur ZMCT103C et de l’ADC interne.',
+    resolution: '10 bits (calcul RMS sur 32 échantillons).',
+    rawRange: '0 à ≈512 bits RMS autour de la valeur médiane.',
+    physicalRange: 'Plage proportionnelle au courant AC selon la calibration du capteur.',
+    rawTagSuffix: '_bits',
+    notes: [
+      'Déterminez l’échelle à partir de la sensibilité du capteur (A/bit).',
+      'Un décalage positif peut compenser la dérive du zéro.'
+    ]
+  },
+  div: {
+    title: 'Pont diviseur DC',
+    summary: 'Mesure une tension continue via un pont diviseur raccordé à l’ADC interne.',
+    resolution: '10 bits (0 à 1023 codes).',
+    rawRange: '0 à 1023 bits bruts (moyenne de 32 échantillons).',
+    physicalRange: '≈ 0 à 1,0 V en entrée A0 avant application du rapport du pont.',
+    rawTagSuffix: '_bits',
+    notes: [
+      'Ajustez l’échelle selon le rapport du pont pour retrouver la tension réelle.',
+      'Le décalage corrige l’offset éventuel dû aux résistances.'
+    ]
+  },
+  disabled: {
+    title: 'Entrée désactivée',
+    summary: 'La voie n’est pas utilisée tant qu’un type actif n’est pas sélectionné.',
+    notes: [
+      'Activez la voie et choisissez un type pour commencer la mesure.'
+    ]
+  }
+};
+
+const OUTPUT_TYPE_DETAILS = {
+  pwm010: {
+    title: 'Sortie PWM → 0–10 V',
+    summary: 'Pilote un convertisseur PWM/analogique pour générer une tension 0–10 V.',
+    resolution: '10 bits (0 à 1023 de rapport cyclique).',
+    rawRange: '0 à 1023 (pour le rapport cyclique PWM).',
+    physicalRange: '≈ 0 à 10 V après conversion.',
+    notes: [
+      'Envoyez la consigne en volts ; l’échelle et le décalage adaptent la conversion en PWM.',
+      'Ajustez la fréquence PWM en fonction des besoins de votre module 0–10 V.'
+    ]
+  },
+  gpio: {
+    title: 'Sortie GPIO',
+    summary: 'Commande directe d’un GPIO numérique de l’ESP8266.',
+    resolution: '1 bit (niveau logique bas ou haut).',
+    physicalRange: '0 V (LOW) ou 3,3 V (HIGH) sur la broche sélectionnée.',
+    notes: [
+      'Toute consigne supérieure à 0,5 est interprétée comme HIGH.',
+      'Utilisez ce mode pour piloter des relais ou des LEDs avec adaptation appropriée.'
+    ]
+  },
+  mcp4725: {
+    title: 'Sortie DAC MCP4725',
+    summary: 'Génère une tension analogique via le DAC I²C MCP4725.',
+    resolution: '12 bits (0 à 4095 codes).',
+    rawRange: '0 à 4095 codes DAC.',
+    physicalRange: '0 à VCC du module (souvent 5 V).',
+    notes: [
+      'L’échelle traduit vos unités physiques en codes DAC (ex. 819 pour ≈1 V à 5 V).',
+      'Vérifiez l’adresse I²C (0x60 ou 0x61) selon le cavalier matériel.'
+    ]
+  },
+  disabled: {
+    title: 'Sortie désactivée',
+    summary: 'Aucun signal n’est généré tant que la voie reste désactivée.',
+    notes: [
+      'Activez la voie et choisissez un type pour la piloter.'
+    ]
+  }
+};
+
+function defaultIoName(kind, index) {
+  const baseIndex = Number.isFinite(index) ? index : 0;
+  return kind === 'input' ? `IN${baseIndex + 1}` : `OUT${baseIndex + 1}`;
+}
+
+function normaliseTagSlug(name) {
+  if (!name) return '';
+  const normalised = name.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const slug = normalised.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return slug;
+}
+
+function getIoExplanation(kind, data, fallbackName, indexHint) {
+  const dictionaries = kind === 'input' ? INPUT_TYPE_DETAILS : OUTPUT_TYPE_DETAILS;
+  const typeKey = data.type && dictionaries[data.type] ? data.type : 'disabled';
+  const base = dictionaries[typeKey] || dictionaries.disabled;
+  let name = data.name && data.name.trim().length ? data.name.trim() : '';
+  if (!name) {
+    if (fallbackName) {
+      name = fallbackName;
+    } else {
+      name = defaultIoName(kind, Number.isFinite(indexHint) ? indexHint : 0);
+    }
+  }
+  const lines = [];
+  if (name) {
+    lines.push(`Tag JSON : ${name}`);
+  }
+  if (base.rawTagSuffix) {
+    const slug = normaliseTagSlug(name);
+    if (slug) {
+      const rawLabel = `${slug}${base.rawTagSuffix}`;
+      if (base.rawRange) {
+        lines.push(`Tag brut suggéré : ${rawLabel} (${base.rawRange})`);
+      } else {
+        lines.push(`Tag brut suggéré : ${rawLabel}`);
+      }
+    }
+  }
+  if (base.resolution) {
+    lines.push(`Résolution : ${base.resolution}`);
+  }
+  if (base.rawRange && !base.rawTagSuffix) {
+    lines.push(`Valeur brute : ${base.rawRange}`);
+  }
+  if (base.physicalRange) {
+    lines.push(`Plage physique : ${base.physicalRange}`);
+  }
+  if (Array.isArray(base.notes)) {
+    base.notes.forEach(note => lines.push(note));
+  }
+  return {
+    title: base.title,
+    summary: base.summary,
+    lines
+  };
+}
 
 let inputs = [];
 let outputs = [];
@@ -632,37 +815,55 @@ function updateIoCounters() {
   if (outCounter) outCounter.textContent = `${outputs.length} / ${MAX_OUTPUTS}`;
 }
 
-function describeInput(item) {
-  const details = [];
-  if (['adc','div','zmpt','zmct'].includes(item.type) && item.pin) {
-    details.push(`Pin : ${item.pin}`);
+function describeInput(item, index) {
+  const fallbackName = item && item.name && item.name.trim()
+    ? item.name.trim()
+    : `IN${(index != null ? index : 0) + 1}`;
+  const explanation = getIoExplanation('input', item || {}, fallbackName, index);
+  const details = explanation.lines.slice();
+  if (item && ['adc','div','zmpt','zmct'].includes(item.type) && item.pin) {
+    details.push(`Broche utilisée : ${item.pin}`);
   }
-  if (item.type === 'ads1115') {
+  if (item && item.type === 'ads1115') {
     details.push(`Canal ADS1115 : A${item.adsChannel}`);
   }
-  if (item.type === 'remote') {
-    if (item.remoteNode) details.push(`Nœud : ${item.remoteNode}`);
+  if (item && item.type === 'remote') {
+    if (item.remoteNode) details.push(`Nœud distant : ${item.remoteNode}`);
     if (item.remoteName) details.push(`Nom distant : ${item.remoteName}`);
   }
-  details.push(`Échelle : ${item.scale}`);
-  details.push(`Décalage : ${item.offset}`);
-  if (item.unit) details.push(`Unité : ${item.unit}`);
+  if (item && Number.isFinite(item.scale)) {
+    details.push(`Échelle appliquée : ${item.scale}`);
+  }
+  if (item && Number.isFinite(item.offset)) {
+    details.push(`Décalage appliqué : ${item.offset}`);
+  }
+  if (item && item.unit) {
+    details.push(`Unité de restitution : ${item.unit}`);
+  }
   return details;
 }
 
-function describeOutput(item) {
-  const details = [];
-  if ((item.type === 'pwm010' || item.type === 'gpio') && item.pin) {
-    details.push(`Pin : ${item.pin}`);
+function describeOutput(item, index) {
+  const fallbackName = item && item.name && item.name.trim()
+    ? item.name.trim()
+    : `OUT${(index != null ? index : 0) + 1}`;
+  const explanation = getIoExplanation('output', item || {}, fallbackName, index);
+  const details = explanation.lines.slice();
+  if (item && (item.type === 'pwm010' || item.type === 'gpio') && item.pin) {
+    details.push(`Broche utilisée : ${item.pin}`);
   }
-  if (item.type === 'pwm010') {
+  if (item && item.type === 'pwm010') {
     details.push(`Fréquence PWM : ${item.pwmFreq} Hz`);
   }
-  if (item.type === 'mcp4725') {
+  if (item && item.type === 'mcp4725') {
     details.push(`Adresse I²C : ${item.i2cAddress}`);
   }
-  details.push(`Gain : ${item.scale}`);
-  details.push(`Décalage : ${item.offset}`);
+  if (item && Number.isFinite(item.scale)) {
+    details.push(`Échelle appliquée : ${item.scale}`);
+  }
+  if (item && Number.isFinite(item.offset)) {
+    details.push(`Décalage appliqué : ${item.offset}`);
+  }
   return details;
 }
 
@@ -722,7 +923,7 @@ function renderIoList(kind) {
     card.appendChild(header);
     const detailList = document.createElement('ul');
     detailList.className = 'io-details';
-    const lines = kind === 'input' ? describeInput(item) : describeOutput(item);
+    const lines = kind === 'input' ? describeInput(item, idx) : describeOutput(item, idx);
     lines.forEach(text => {
       const li = document.createElement('li');
       li.textContent = text;
@@ -967,6 +1168,30 @@ function renderTypeSpecificFields(data, kind) {
   }
 }
 
+function renderModalInfoPanel(kind, data, indexHint) {
+  const panel = document.getElementById('modalInfo');
+  if (!panel) return;
+  const effectiveIndex = indexHint != null ? indexHint : (kind === 'input' ? inputs.length : outputs.length);
+  const fallback = data && data.name && data.name.trim().length
+    ? data.name.trim()
+    : defaultIoName(kind, effectiveIndex);
+  const info = getIoExplanation(kind, data || {}, fallback, effectiveIndex);
+  panel.innerHTML = '';
+  const titleEl = document.createElement('h3');
+  titleEl.textContent = info.title;
+  panel.appendChild(titleEl);
+  const summaryEl = document.createElement('p');
+  summaryEl.textContent = info.summary;
+  panel.appendChild(summaryEl);
+  const listEl = document.createElement('ul');
+  info.lines.forEach(text => {
+    const li = document.createElement('li');
+    li.textContent = text;
+    listEl.appendChild(li);
+  });
+  panel.appendChild(listEl);
+}
+
 function renderModalForm() {
   if (!modalState) return;
   const { kind, index, data } = modalState;
@@ -990,6 +1215,7 @@ function renderModalForm() {
   nameInput.value = data.name || '';
   nameInput.oninput = (ev) => {
     modalState.data.name = ev.target.value;
+    renderModalInfoPanel(kind, modalState.data, index);
   };
   typeSelect.innerHTML = '';
   let options = typeOptionsForKind(kind);
@@ -1039,6 +1265,7 @@ function renderModalForm() {
     unitRow.classList.add('hidden');
   }
   renderTypeSpecificFields(modalState.data, kind);
+  renderModalInfoPanel(kind, modalState.data, index);
 }
 
 function handleModalSubmit(event) {

--- a/data/examples/index.html
+++ b/data/examples/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>MiniLabBox – Bibliothèque d'exemples IO</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 960px; }
+    h1 { margin-top: 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1em; padding: 0; list-style: none; }
+    .card { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    .card h2 { margin: 0 0 0.4em; font-size: 1.05em; }
+    .card p { margin: 0 0 0.6em; font-size: 0.95em; color: #34495e; }
+    .card a { color: #1d5fa7; text-decoration: none; font-weight: bold; }
+    .card a:hover { text-decoration: underline; }
+    .category { margin-top: 2em; }
+  </style>
+  <script src="../auth.js"></script>
+</head>
+<body>
+<h1>Bibliothèque d'exemples des entrées/sorties</h1>
+<p>Choisissez un exemple adapté au type d'entrée ou de sortie que vous configurez. Chaque page reprend la plage de fonctionnement, le tag JSON utilisé dans les API et des conseils de mise en œuvre.</p>
+
+<section class="category">
+  <h2>Entrées</h2>
+  <ul class="grid">
+    <li class="card">
+      <h2>ADC interne (A0)</h2>
+      <p>Visualiser la conversion 10 bits de l'ADC embarqué et obtenir le nombre de bits bruts.</p>
+      <a href="input-adc.html">Ouvrir l'exemple ADC</a>
+    </li>
+    <li class="card">
+      <h2>ADC externe ADS1115</h2>
+      <p>Suivre un canal ADS1115 et convertir les codes 16 bits en tension.</p>
+      <a href="input-ads1115.html">Ouvrir l'exemple ADS1115</a>
+    </li>
+    <li class="card">
+      <h2>Entrée distante</h2>
+      <p>Superviser une mesure reçue d'un autre nœud et vérifier les noms distants.</p>
+      <a href="input-remote.html">Ouvrir l'exemple distant</a>
+    </li>
+    <li class="card">
+      <h2>Capteur ZMPT101B</h2>
+      <p>Convertir la valeur RMS en tension efficace et contrôler l'offset AC.</p>
+      <a href="input-zmpt.html">Ouvrir l'exemple ZMPT</a>
+    </li>
+    <li class="card">
+      <h2>Capteur ZMCT103C</h2>
+      <p>Observer la mesure de courant AC RMS et ajuster le gain A/bit.</p>
+      <a href="input-zmct.html">Ouvrir l'exemple ZMCT</a>
+    </li>
+    <li class="card">
+      <h2>Pont diviseur DC</h2>
+      <p>Calculer la tension réelle à partir des bits de l'ADC et du rapport du pont.</p>
+      <a href="input-div.html">Ouvrir l'exemple Diviseur</a>
+    </li>
+  </ul>
+</section>
+
+<section class="category">
+  <h2>Sorties</h2>
+  <ul class="grid">
+    <li class="card">
+      <h2>PWM → 0–10 V</h2>
+      <p>Envoyer une consigne en volts et visualiser le rapport cyclique PWM calculé.</p>
+      <a href="output-pwm010.html">Ouvrir l'exemple PWM</a>
+    </li>
+    <li class="card">
+      <h2>Sortie GPIO</h2>
+      <p>Basculer un niveau logique et vérifier l'état de la sortie numérique.</p>
+      <a href="output-gpio.html">Ouvrir l'exemple GPIO</a>
+    </li>
+    <li class="card">
+      <h2>DAC MCP4725</h2>
+      <p>Régler une consigne analogique et convertir la valeur en codes 12 bits.</p>
+      <a href="output-mcp4725.html">Ouvrir l'exemple DAC</a>
+    </li>
+  </ul>
+</section>
+
+<p>Pour un scénario combiné (puissance active), l'ancien exemple reste disponible : <a href="../example.html">mesure de puissance</a>.</p>
+
+<script>
+  ensureSession().catch(err => console.error(err));
+</script>
+</body>
+</html>

--- a/data/examples/input-adc.html
+++ b/data/examples/input-adc.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Entrée ADC interne</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { color: #c0392b; font-size: 0.9em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – ADC interne (A0)</h1>
+<p class="hint">Cette page affiche en direct une entrée configurée en <strong>ADC interne</strong>. L'ESP8266 mesure 10 bits (0–1023) correspondant à environ 0–1,0 V sur la broche A0. Utilisez l'échelle pour convertir ces bits en volts ou en toute autre unité.</p>
+
+<div class="controls">
+  <label for="inputSelect">Entrée ADC&nbsp;:</label>
+  <select id="inputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de l'entrée</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code> | Tag brut suggéré&nbsp;: <code id="tagRaw">—</code></p>
+  <p class="hint">Plage brute&nbsp;: 0–1023 bits | Plage physique typique&nbsp;: 0–1,0 V</p>
+  <p class="hint">Broche mesurée&nbsp;: <span id="pinInfo">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Mesure instantanée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Valeur convertie</span>
+      <strong id="value">—</strong>
+      <span id="unit">—</span>
+    </div>
+    <div class="metric">
+      <span>Bits estimés</span>
+      <strong id="rawBits">—</strong>
+      <span>0 à 1023</span>
+    </div>
+    <div class="metric">
+      <span>Échelle / Décalage</span>
+      <strong id="scaleInfo">—</strong>
+      <span>gain | offset</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Astuce : pour obtenir des volts à partir des bits, utilisez une échelle proche de 0,001 (1/1023). Un décalage positif permet de corriger une éventuelle dérive du zéro.</p>
+
+<script>
+(function() {
+  let state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {}
+  };
+
+  const selectEl = document.getElementById('inputSelect');
+  const valueEl = document.getElementById('value');
+  const unitEl = document.getElementById('unit');
+  const rawEl = document.getElementById('rawBits');
+  const tagEl = document.getElementById('tagName');
+  const tagRawEl = document.getElementById('tagRaw');
+  const scaleEl = document.getElementById('scaleInfo');
+  const statusEl = document.getElementById('status');
+  const pinInfoEl = document.getElementById('pinInfo');
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      tagRawEl.textContent = '—';
+      scaleEl.textContent = '—';
+      unitEl.textContent = '—';
+      pinInfoEl.textContent = '—';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const slug = ExampleUtils.slugFromName(entry.name);
+    tagRawEl.textContent = slug ? `${slug}_bits` : '—';
+    unitEl.textContent = entry.unit || '—';
+    pinInfoEl.textContent = entry.pin || 'A0';
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      valueEl.textContent = '—';
+      rawEl.textContent = '—';
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) return;
+    const current = state.values[state.selected];
+    valueEl.textContent = ExampleUtils.formatNumber(current);
+    const raw = ExampleUtils.computeRawValue(current, entry.scale, entry.offset);
+    rawEl.textContent = raw === null ? '—' : raw.toFixed(0);
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchInputsValues();
+      state.values = map;
+      updateDisplay();
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Erreur de lecture';
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.inputsByType(cfg, 'adc');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucune entrée ADC active';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      statusEl.textContent = 'Activez une entrée ADC dans la configuration.';
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      opt.textContent = entry.name;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      statusEl.textContent = err.message || 'Authentification requise';
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/input-ads1115.html
+++ b/data/examples/input-ads1115.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Entrée ADS1115</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { color: #c0392b; font-size: 0.9em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – ADC externe ADS1115</h1>
+<p class="hint">L'ADS1115 fournit une conversion 16 bits (0–32767) sur une plage 0–4,096 V avec le gain ×1 utilisé par MiniLabBox. Sélectionnez l'entrée pour vérifier la lecture et déduire les bits bruts.</p>
+
+<div class="controls">
+  <label for="inputSelect">Entrée ADS1115&nbsp;:</label>
+  <select id="inputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de l'entrée</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code> | Tag brut suggéré&nbsp;: <code id="tagRaw">—</code></p>
+  <p class="hint">Plage brute&nbsp;: 0–32767 codes | Plage physique typique&nbsp;: 0–4,096 V</p>
+  <p class="hint">Canal ADS1115&nbsp;: <span id="channelInfo">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Mesure instantanée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Valeur convertie</span>
+      <strong id="value">—</strong>
+      <span id="unit">—</span>
+    </div>
+    <div class="metric">
+      <span>Codes bruts estimés</span>
+      <strong id="rawBits">—</strong>
+      <span>0 à 32767</span>
+    </div>
+    <div class="metric">
+      <span>Échelle / Décalage</span>
+      <strong id="scaleInfo">—</strong>
+      <span>gain | offset</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Astuce : avec un gain de 1, chaque bit vaut environ 125 µV (4,096 V / 32768). Utilisez cette valeur pour calculer l'échelle qui convertit les codes en volts.</p>
+
+<script>
+(function() {
+  let state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {}
+  };
+
+  const selectEl = document.getElementById('inputSelect');
+  const valueEl = document.getElementById('value');
+  const unitEl = document.getElementById('unit');
+  const rawEl = document.getElementById('rawBits');
+  const tagEl = document.getElementById('tagName');
+  const tagRawEl = document.getElementById('tagRaw');
+  const scaleEl = document.getElementById('scaleInfo');
+  const channelEl = document.getElementById('channelInfo');
+  const statusEl = document.getElementById('status');
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      tagRawEl.textContent = '—';
+      scaleEl.textContent = '—';
+      unitEl.textContent = '—';
+      channelEl.textContent = '—';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const slug = ExampleUtils.slugFromName(entry.name);
+    tagRawEl.textContent = slug ? `${slug}_bits` : '—';
+    unitEl.textContent = entry.unit || '—';
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    channelEl.textContent = Number.isFinite(entry.adsChannel) ? `A${entry.adsChannel}` : '—';
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      valueEl.textContent = '—';
+      rawEl.textContent = '—';
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) return;
+    const current = state.values[state.selected];
+    valueEl.textContent = ExampleUtils.formatNumber(current);
+    const raw = ExampleUtils.computeRawValue(current, entry.scale, entry.offset);
+    rawEl.textContent = raw === null ? '—' : raw.toFixed(0);
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchInputsValues();
+      state.values = map;
+      updateDisplay();
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Erreur de lecture';
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.inputsByType(cfg, 'ads1115');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucune entrée ADS1115 active';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      statusEl.textContent = 'Activez le module ADS1115 et ajoutez une entrée.';
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      const label = Number.isFinite(entry.adsChannel) ? `${entry.name} (A${entry.adsChannel})` : entry.name;
+      opt.textContent = label;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      statusEl.textContent = err.message || 'Authentification requise';
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/input-div.html
+++ b/data/examples/input-div.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Pont diviseur DC</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { color: #c0392b; font-size: 0.9em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – Pont diviseur DC</h1>
+<p class="hint">Le mode <strong>Diviseur DC</strong> lit 32 échantillons de l'ADC 10 bits et en calcule la moyenne. Utilisez l'échelle pour retrouver la tension réelle avant division.</p>
+
+<div class="controls">
+  <label for="inputSelect">Entrée Diviseur&nbsp;:</label>
+  <select id="inputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de l'entrée</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code> | Tag brut suggéré&nbsp;: <code id="tagRaw">—</code></p>
+  <p class="hint">Plage brute&nbsp;: 0–1023 bits | Plage physique dépend du rapport du pont</p>
+  <p class="hint">Broche mesurée&nbsp;: <span id="pinInfo">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Mesure instantanée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Tension calculée</span>
+      <strong id="value">—</strong>
+      <span id="unit">—</span>
+    </div>
+    <div class="metric">
+      <span>Bits moyens</span>
+      <strong id="rawBits">—</strong>
+      <span>0 à 1023</span>
+    </div>
+    <div class="metric">
+      <span>Échelle / Décalage</span>
+      <strong id="scaleInfo">—</strong>
+      <span>gain | offset</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Astuce : mesurez la tension réelle à l'entrée du pont et ajustez l'échelle selon le rapport R1/R2 pour obtenir la valeur en volts.</p>
+
+<script>
+(function() {
+  let state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {}
+  };
+
+  const selectEl = document.getElementById('inputSelect');
+  const valueEl = document.getElementById('value');
+  const unitEl = document.getElementById('unit');
+  const rawEl = document.getElementById('rawBits');
+  const tagEl = document.getElementById('tagName');
+  const tagRawEl = document.getElementById('tagRaw');
+  const scaleEl = document.getElementById('scaleInfo');
+  const pinEl = document.getElementById('pinInfo');
+  const statusEl = document.getElementById('status');
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      tagRawEl.textContent = '—';
+      unitEl.textContent = '—';
+      scaleEl.textContent = '—';
+      pinEl.textContent = '—';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const slug = ExampleUtils.slugFromName(entry.name);
+    tagRawEl.textContent = slug ? `${slug}_bits` : '—';
+    unitEl.textContent = entry.unit || '—';
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    pinEl.textContent = entry.pin || 'A0';
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      valueEl.textContent = '—';
+      rawEl.textContent = '—';
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) return;
+    const current = state.values[state.selected];
+    valueEl.textContent = ExampleUtils.formatNumber(current);
+    const raw = ExampleUtils.computeRawValue(current, entry.scale, entry.offset);
+    rawEl.textContent = raw === null ? '—' : raw.toFixed(0);
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchInputsValues();
+      state.values = map;
+      updateDisplay();
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Erreur de lecture';
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.inputsByType(cfg, 'div');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucun diviseur actif';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      statusEl.textContent = 'Activez le module Diviseur et assignez une broche.';
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      const label = entry.pin ? `${entry.name} (${entry.pin})` : entry.name;
+      opt.textContent = label;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      statusEl.textContent = err.message || 'Authentification requise';
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/input-remote.html
+++ b/data/examples/input-remote.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Entrée distante</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.3em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { color: #c0392b; font-size: 0.9em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – Entrée distante</h1>
+<p class="hint">Une entrée de type <strong>remote</strong> applique une échelle à la valeur reçue d'un autre nœud MiniLabBox. Vérifiez ici que le nom de nœud et le nom distant correspondent et observez la valeur avant/après conversion.</p>
+
+<div class="controls">
+  <label for="inputSelect">Entrée distante&nbsp;:</label>
+  <select id="inputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de l'entrée</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code></p>
+  <p class="hint">Nœud distant&nbsp;: <span id="remoteNode">—</span> | Nom distant&nbsp;: <span id="remoteName">—</span></p>
+  <p class="hint">Échelle appliquée&nbsp;: <span id="scaleInfo">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Valeurs reçues</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Valeur convertie</span>
+      <strong id="value">—</strong>
+      <span id="unit">—</span>
+    </div>
+    <div class="metric">
+      <span>Valeur reçue (avant échelle)</span>
+      <strong id="rawValue">—</strong>
+      <span>Directement depuis le nœud distant</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Assurez-vous que le nœud distant diffuse bien la mesure via UDP et que les identifiants <em>remoteNode</em> et <em>remoteName</em> correspondent exactement à sa configuration.</p>
+
+<script>
+(function() {
+  let state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {}
+  };
+
+  const selectEl = document.getElementById('inputSelect');
+  const valueEl = document.getElementById('value');
+  const unitEl = document.getElementById('unit');
+  const rawEl = document.getElementById('rawValue');
+  const tagEl = document.getElementById('tagName');
+  const nodeEl = document.getElementById('remoteNode');
+  const nameEl = document.getElementById('remoteName');
+  const scaleEl = document.getElementById('scaleInfo');
+  const statusEl = document.getElementById('status');
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      nodeEl.textContent = '—';
+      nameEl.textContent = '—';
+      unitEl.textContent = '—';
+      scaleEl.textContent = '—';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    nodeEl.textContent = entry.remoteNode || '—';
+    nameEl.textContent = entry.remoteName || '—';
+    unitEl.textContent = entry.unit || '—';
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      valueEl.textContent = '—';
+      rawEl.textContent = '—';
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) return;
+    const current = state.values[state.selected];
+    valueEl.textContent = ExampleUtils.formatNumber(current);
+    const remoteVal = ExampleUtils.computeRawValue(current, entry.scale, entry.offset);
+    rawEl.textContent = remoteVal === null ? '—' : ExampleUtils.formatNumber(remoteVal);
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchInputsValues();
+      state.values = map;
+      updateDisplay();
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Erreur de lecture';
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.inputsByType(cfg, 'remote');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucune entrée distante active';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      statusEl.textContent = 'Ajoutez une entrée remote pour voir les valeurs reçues.';
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      const labelParts = [entry.name];
+      if (entry.remoteNode) labelParts.push(`← ${entry.remoteNode}`);
+      opt.textContent = labelParts.join(' ');
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      statusEl.textContent = err.message || 'Authentification requise';
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/input-zmct.html
+++ b/data/examples/input-zmct.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Capteur de courant AC (ZMCT103C)</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { color: #c0392b; font-size: 0.9em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – Capteur ZMCT103C</h1>
+<p class="hint">Le transformateur de courant ZMCT103C délivre un signal AC centré autour de 512 (10 bits). La valeur affichée correspond au courant efficace après application de l'échelle configurée.</p>
+
+<div class="controls">
+  <label for="inputSelect">Entrée ZMCT&nbsp;:</label>
+  <select id="inputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de l'entrée</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code> | Tag brut suggéré&nbsp;: <code id="tagRaw">—</code></p>
+  <p class="hint">Plage RMS estimée&nbsp;: 0–512 bits | Sensibilité dépendante du capteur (A<sub>RMS</sub>)</p>
+  <p class="hint">Broche mesurée&nbsp;: <span id="pinInfo">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Mesure instantanée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Courant efficace</span>
+      <strong id="value">—</strong>
+      <span id="unit">—</span>
+    </div>
+    <div class="metric">
+      <span>Bits RMS estimés</span>
+      <strong id="rawBits">—</strong>
+      <span>0 à 512</span>
+    </div>
+    <div class="metric">
+      <span>Échelle / Décalage</span>
+      <strong id="scaleInfo">—</strong>
+      <span>gain | offset</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Astuce : calibrez l'échelle avec une charge connue pour obtenir des ampères RMS. Vérifiez également le nombre de spires autour du transformateur.</p>
+
+<script>
+(function() {
+  let state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {}
+  };
+
+  const selectEl = document.getElementById('inputSelect');
+  const valueEl = document.getElementById('value');
+  const unitEl = document.getElementById('unit');
+  const rawEl = document.getElementById('rawBits');
+  const tagEl = document.getElementById('tagName');
+  const tagRawEl = document.getElementById('tagRaw');
+  const scaleEl = document.getElementById('scaleInfo');
+  const pinEl = document.getElementById('pinInfo');
+  const statusEl = document.getElementById('status');
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      tagRawEl.textContent = '—';
+      unitEl.textContent = '—';
+      scaleEl.textContent = '—';
+      pinEl.textContent = '—';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const slug = ExampleUtils.slugFromName(entry.name);
+    tagRawEl.textContent = slug ? `${slug}_bits` : '—';
+    unitEl.textContent = entry.unit || '—';
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    pinEl.textContent = entry.pin || 'A0';
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      valueEl.textContent = '—';
+      rawEl.textContent = '—';
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) return;
+    const current = state.values[state.selected];
+    valueEl.textContent = ExampleUtils.formatNumber(current);
+    const raw = ExampleUtils.computeRawValue(current, entry.scale, entry.offset);
+    rawEl.textContent = raw === null ? '—' : raw.toFixed(0);
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchInputsValues();
+      state.values = map;
+      updateDisplay();
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Erreur de lecture';
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.inputsByType(cfg, 'zmct');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucun capteur ZMCT actif';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      statusEl.textContent = 'Activez le module ZMCT et assignez une broche.';
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      const label = entry.pin ? `${entry.name} (${entry.pin})` : entry.name;
+      opt.textContent = label;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      statusEl.textContent = err.message || 'Authentification requise';
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/input-zmpt.html
+++ b/data/examples/input-zmpt.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Capteur de tension AC (ZMPT101B)</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { color: #c0392b; font-size: 0.9em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – Capteur ZMPT101B</h1>
+<p class="hint">Le module ZMPT101B délivre une tension centrée autour de mi-échelle. MiniLabBox calcule la valeur RMS de la composante AC à partir de 32 échantillons. Sur l'ADC 10 bits, la composante RMS varie approximativement de 0 à 512 bits.</p>
+
+<div class="controls">
+  <label for="inputSelect">Entrée ZMPT&nbsp;:</label>
+  <select id="inputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de l'entrée</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code> | Tag brut suggéré&nbsp;: <code id="tagRaw">—</code></p>
+  <p class="hint">Plage RMS estimée&nbsp;: 0–512 bits | Plage physique dépend du calibrage (V<sub>RMS</sub>)</p>
+  <p class="hint">Broche mesurée&nbsp;: <span id="pinInfo">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Mesure instantanée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Tension efficace</span>
+      <strong id="value">—</strong>
+      <span id="unit">—</span>
+    </div>
+    <div class="metric">
+      <span>Bits RMS estimés</span>
+      <strong id="rawBits">—</strong>
+      <span>0 à 512</span>
+    </div>
+    <div class="metric">
+      <span>Échelle / Décalage</span>
+      <strong id="scaleInfo">—</strong>
+      <span>gain | offset</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Conseil : réalisez une mesure de référence (par ex. 230 V AC) pour déterminer l'échelle (V/bit). Un offset peut compenser une asymétrie du capteur.</p>
+
+<script>
+(function() {
+  let state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {}
+  };
+
+  const selectEl = document.getElementById('inputSelect');
+  const valueEl = document.getElementById('value');
+  const unitEl = document.getElementById('unit');
+  const rawEl = document.getElementById('rawBits');
+  const tagEl = document.getElementById('tagName');
+  const tagRawEl = document.getElementById('tagRaw');
+  const scaleEl = document.getElementById('scaleInfo');
+  const pinEl = document.getElementById('pinInfo');
+  const statusEl = document.getElementById('status');
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      tagRawEl.textContent = '—';
+      unitEl.textContent = '—';
+      scaleEl.textContent = '—';
+      pinEl.textContent = '—';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const slug = ExampleUtils.slugFromName(entry.name);
+    tagRawEl.textContent = slug ? `${slug}_bits` : '—';
+    unitEl.textContent = entry.unit || '—';
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    pinEl.textContent = entry.pin || 'A0';
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      valueEl.textContent = '—';
+      rawEl.textContent = '—';
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) return;
+    const current = state.values[state.selected];
+    valueEl.textContent = ExampleUtils.formatNumber(current);
+    const raw = ExampleUtils.computeRawValue(current, entry.scale, entry.offset);
+    rawEl.textContent = raw === null ? '—' : raw.toFixed(0);
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchInputsValues();
+      state.values = map;
+      updateDisplay();
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Erreur de lecture';
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.inputsByType(cfg, 'zmpt');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucun capteur ZMPT actif';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      statusEl.textContent = 'Activez le module ZMPT et assignez une broche.';
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      const label = entry.pin ? `${entry.name} (${entry.pin})` : entry.name;
+      opt.textContent = label;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      statusEl.textContent = err.message || 'Authentification requise';
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/output-gpio.html
+++ b/data/examples/output-gpio.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Sortie GPIO</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 720px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { font-size: 0.9em; min-height: 1.2em; }
+    .status.ok { color: #2c3e50; }
+    .status:not(.ok) { color: #c0392b; }
+    .badge { display: inline-flex; align-items: center; gap: 0.3em; font-size: 0.85em; padding: 0.2em 0.5em; border-radius: 999px; background: #ecf0f6; color: #34495e; }
+    .badge.active { background: #e8f8f0; color: #2f7a40; }
+    .toggle { display: flex; align-items: center; gap: 0.6em; font-size: 1.1em; }
+    .toggle input { width: 48px; height: 24px; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – Sortie GPIO numérique</h1>
+<p class="hint">Utilisez cette page pour tester une sortie configurée en <strong>GPIO</strong>. Les consignes 0/1 sont converties en niveaux logiques 0 V / 3,3 V sur la broche choisie.</p>
+
+<div class="controls">
+  <label for="outputSelect">Sortie GPIO&nbsp;:</label>
+  <select id="outputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de la sortie</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code></p>
+  <p class="hint">Échelle / Décalage&nbsp;: <span id="scaleInfo">—</span> (le seuil 0,5 déclenche l’état HIGH)</p>
+  <p class="hint">État&nbsp;: <span class="badge" id="activeBadge">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Envoyer un niveau logique</h2>
+  <div class="toggle">
+    <label for="toggle">Niveau de sortie&nbsp;:</label>
+    <input type="checkbox" id="toggle">
+    <span id="toggleLabel">LOW</span>
+  </div>
+  <p class="hint">Décochez pour forcer LOW (0) et cochez pour forcer HIGH (1). L’envoi est immédiat.</p>
+</div>
+
+<div class="panel">
+  <h2>État observé</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Consigne actuelle</span>
+      <strong id="currentValue">—</strong>
+      <span>Valeur reçue via l’API</span>
+    </div>
+    <div class="metric">
+      <span>Niveau logique</span>
+      <strong id="logicLevel">—</strong>
+      <span>0 V ≈ LOW, 3,3 V ≈ HIGH</span>
+    </div>
+  </div>
+</div>
+
+<script>
+(function() {
+  'use strict';
+
+  const state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {},
+    suppressUpdate: false
+  };
+
+  const selectEl = document.getElementById('outputSelect');
+  const statusEl = document.getElementById('status');
+  const tagEl = document.getElementById('tagName');
+  const scaleEl = document.getElementById('scaleInfo');
+  const activeBadge = document.getElementById('activeBadge');
+  const toggleEl = document.getElementById('toggle');
+  const toggleLabel = document.getElementById('toggleLabel');
+  const currentValueEl = document.getElementById('currentValue');
+  const logicLevelEl = document.getElementById('logicLevel');
+
+  function showStatus(message, isError = false) {
+    statusEl.textContent = message || '';
+    if (!message) {
+      statusEl.classList.remove('ok');
+      return;
+    }
+    if (isError) {
+      statusEl.classList.remove('ok');
+    } else {
+      statusEl.classList.add('ok');
+    }
+  }
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      scaleEl.textContent = '—';
+      activeBadge.textContent = '—';
+      activeBadge.classList.remove('active');
+      toggleEl.disabled = true;
+      toggleEl.checked = false;
+      toggleLabel.textContent = 'LOW';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    toggleEl.disabled = false;
+  }
+
+  function applyActiveBadge(data) {
+    if (!data) {
+      activeBadge.textContent = '—';
+      activeBadge.classList.remove('active');
+      return;
+    }
+    if (data.active) {
+      activeBadge.textContent = 'Sortie active';
+      activeBadge.classList.add('active');
+    } else {
+      activeBadge.textContent = 'Sortie désactivée';
+      activeBadge.classList.remove('active');
+    }
+  }
+
+  function updateToggleDisplay(value) {
+    const num = ExampleUtils.normaliseNumber(value);
+    if (num === null) {
+      toggleLabel.textContent = '—';
+      return;
+    }
+    const isHigh = num >= 0.5;
+    toggleEl.checked = isHigh;
+    toggleLabel.textContent = isHigh ? 'HIGH' : 'LOW';
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      currentValueEl.textContent = '—';
+      logicLevelEl.textContent = '—';
+      applyActiveBadge(null);
+      return;
+    }
+    const measurement = state.values[state.selected];
+    const current = measurement ? measurement.value : null;
+    currentValueEl.textContent = ExampleUtils.formatNumber(current, 2);
+    logicLevelEl.textContent = current === null ? '—' : (current >= 0.5 ? 'HIGH' : 'LOW');
+    applyActiveBadge(measurement);
+    if (!state.suppressUpdate) {
+      updateToggleDisplay(current);
+    }
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchOutputsValues();
+      state.values = map;
+      updateDisplay();
+      showStatus('');
+    } catch (err) {
+      showStatus(err.message || 'Erreur de lecture', true);
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function applyToggleChange() {
+    if (!state.selected) {
+      showStatus('Sélectionnez une sortie GPIO.', true);
+      return;
+    }
+    const value = toggleEl.checked ? 1 : 0;
+    state.suppressUpdate = true;
+    try {
+      showStatus('Envoi en cours…');
+      await ExampleUtils.sendOutputValue(state.selected, value);
+      showStatus('Consigne appliquée.');
+      toggleLabel.textContent = value ? 'HIGH' : 'LOW';
+      await refreshValues();
+    } catch (err) {
+      showStatus(err.message || 'Échec de l’envoi.', true);
+      toggleEl.checked = !toggleEl.checked;
+      toggleLabel.textContent = toggleEl.checked ? 'HIGH' : 'LOW';
+    } finally {
+      setTimeout(() => {
+        state.suppressUpdate = false;
+      }, 500);
+    }
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.outputsByType(cfg, 'gpio');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucune sortie GPIO active';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      toggleEl.disabled = true;
+      showStatus('Activez une sortie GPIO dans la configuration.', true);
+      updateInfo(null);
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      opt.textContent = entry.name;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  toggleEl.addEventListener('change', applyToggleChange);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      showStatus(err.message || 'Authentification requise', true);
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/output-mcp4725.html
+++ b/data/examples/output-mcp4725.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Sortie DAC MCP4725</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { font-size: 0.9em; min-height: 1.2em; }
+    .status.ok { color: #2c3e50; }
+    .status:not(.ok) { color: #c0392b; }
+    .badge { display: inline-flex; align-items: center; gap: 0.3em; font-size: 0.85em; padding: 0.2em 0.5em; border-radius: 999px; background: #ecf0f6; color: #34495e; }
+    .badge.active { background: #e8f8f0; color: #2f7a40; }
+    .range-control { display: flex; align-items: center; gap: 0.75em; flex-wrap: wrap; }
+    .range-control input[type="range"] { flex: 1 1 240px; }
+    .range-control input[type="number"] { width: 110px; }
+    .actions { display: flex; gap: 0.5em; }
+    button { padding: 0.4em 0.9em; font-size: 1em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – DAC I²C MCP4725</h1>
+<p class="hint">Pilotez ici une sortie <strong>MCP4725</strong>. Le DAC fournit une tension analogique 12 bits (0–4095 codes) proportionnelle à l’unité configurée (souvent des volts).</p>
+
+<div class="controls">
+  <label for="outputSelect">Sortie DAC&nbsp;:</label>
+  <select id="outputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de la sortie</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code></p>
+  <p class="hint">Échelle / Décalage&nbsp;: <span id="scaleInfo">—</span></p>
+  <p class="hint">Adresse I²C&nbsp;: <code id="i2cInfo">—</code></p>
+  <p class="hint">Plage estimée (d’après l’échelle)&nbsp;: <span id="rangeInfo">—</span></p>
+  <p class="hint">État&nbsp;: <span class="badge" id="activeBadge">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Envoyer une consigne</h2>
+  <div class="range-control">
+    <label for="valueRange">Consigne (typ. 0–5 V)&nbsp;:</label>
+    <input type="range" id="valueRange" min="0" max="5" step="0.05" value="0">
+    <input type="number" id="valueInput" step="0.01" value="0">
+    <div class="actions">
+      <button id="sendBtn" type="button">Appliquer</button>
+      <button id="zeroBtn" type="button">Mettre à 0</button>
+      <button id="fullScaleBtn" type="button">Plein échelle</button>
+    </div>
+  </div>
+</div>
+
+<div class="panel">
+  <h2>Consigne appliquée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Valeur envoyée</span>
+      <strong id="currentValue">—</strong>
+      <span id="unitHint">Unité définie dans la configuration</span>
+    </div>
+    <div class="metric">
+      <span>Code DAC (0–4095)</span>
+      <strong id="rawCode">—</strong>
+      <span>Résolution 12 bits</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Astuce : avec une alimentation 5 V et une sortie en volts, l’échelle typique est de <code>819</code> (4095 codes / 5 V). Utilisez le bouton « Plein échelle » pour atteindre rapidement la tension maximale.</p>
+
+<script>
+(function() {
+  'use strict';
+
+  const state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {},
+    editing: false,
+    editTimeout: null
+  };
+
+  const selectEl = document.getElementById('outputSelect');
+  const statusEl = document.getElementById('status');
+  const tagEl = document.getElementById('tagName');
+  const scaleEl = document.getElementById('scaleInfo');
+  const rangeInfoEl = document.getElementById('rangeInfo');
+  const i2cInfoEl = document.getElementById('i2cInfo');
+  const activeBadge = document.getElementById('activeBadge');
+  const rangeEl = document.getElementById('valueRange');
+  const inputEl = document.getElementById('valueInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const zeroBtn = document.getElementById('zeroBtn');
+  const fullScaleBtn = document.getElementById('fullScaleBtn');
+  const currentValueEl = document.getElementById('currentValue');
+  const rawCodeEl = document.getElementById('rawCode');
+  const unitHintEl = document.getElementById('unitHint');
+
+  function showStatus(message, isError = false) {
+    statusEl.textContent = message || '';
+    if (!message) {
+      statusEl.classList.remove('ok');
+      return;
+    }
+    if (isError) {
+      statusEl.classList.remove('ok');
+    } else {
+      statusEl.classList.add('ok');
+    }
+  }
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function clearEditingSoon() {
+    if (state.editTimeout) {
+      clearTimeout(state.editTimeout);
+    }
+    state.editTimeout = setTimeout(() => {
+      state.editing = false;
+    }, 1500);
+  }
+
+  function markEditing() {
+    state.editing = true;
+    clearEditingSoon();
+  }
+
+  function computeRangeText(scale, offset) {
+    const gain = ExampleUtils.normaliseNumber(scale);
+    const off = ExampleUtils.normaliseNumber(offset) ?? 0;
+    if (!Number.isFinite(gain) || gain === 0) {
+      return '—';
+    }
+    const min = (0 - off) / gain;
+    const max = (4095 - off) / gain;
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return '—';
+    }
+    const sorted = [min, max].sort((a, b) => a - b);
+    return `${sorted[0].toFixed(3)} → ${sorted[1].toFixed(3)}`;
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      scaleEl.textContent = '—';
+      rangeInfoEl.textContent = '—';
+      i2cInfoEl.textContent = '—';
+      activeBadge.textContent = '—';
+      activeBadge.classList.remove('active');
+      rangeEl.disabled = true;
+      inputEl.disabled = true;
+      sendBtn.disabled = true;
+      zeroBtn.disabled = true;
+      fullScaleBtn.disabled = true;
+      unitHintEl.textContent = 'Unité définie dans la configuration';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    rangeInfoEl.textContent = computeRangeText(entry.scale, entry.offset);
+    i2cInfoEl.textContent = entry.i2cAddress || '0x60 (défaut)';
+    rangeEl.disabled = false;
+    inputEl.disabled = false;
+    sendBtn.disabled = false;
+    zeroBtn.disabled = false;
+    fullScaleBtn.disabled = false;
+    unitHintEl.textContent = 'Unité définie dans la configuration';
+  }
+
+  function applyActiveBadge(data) {
+    if (!data) {
+      activeBadge.textContent = '—';
+      activeBadge.classList.remove('active');
+      return;
+    }
+    if (data.active) {
+      activeBadge.textContent = 'Sortie active';
+      activeBadge.classList.add('active');
+    } else {
+      activeBadge.textContent = 'Sortie désactivée';
+      activeBadge.classList.remove('active');
+    }
+  }
+
+  function clamp(value, min, max) {
+    if (!Number.isFinite(value)) return value;
+    if (Number.isFinite(min) && value < min) return min;
+    if (Number.isFinite(max) && value > max) return max;
+    return value;
+  }
+
+  function updateControlsFromValue(value) {
+    const num = ExampleUtils.normaliseNumber(value);
+    if (num === null) {
+      return;
+    }
+    const clamped = clamp(num, Number(rangeEl.min), Number(rangeEl.max));
+    rangeEl.value = clamped;
+    inputEl.value = num.toFixed(3);
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      currentValueEl.textContent = '—';
+      rawCodeEl.textContent = '—';
+      applyActiveBadge(null);
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    const measurement = state.values[state.selected];
+    const current = measurement ? measurement.value : null;
+    currentValueEl.textContent = ExampleUtils.formatNumber(current, 3);
+    applyActiveBadge(measurement);
+    if (entry) {
+      const raw = ExampleUtils.applyOutputScale(current, entry.scale, entry.offset);
+      rawCodeEl.textContent = raw === null ? '—' : raw.toFixed(0);
+      if (!state.editing) {
+        updateControlsFromValue(current);
+      }
+    } else {
+      rawCodeEl.textContent = '—';
+    }
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchOutputsValues();
+      state.values = map;
+      updateDisplay();
+      showStatus('');
+    } catch (err) {
+      showStatus(err.message || 'Erreur de lecture', true);
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function sendValue(value) {
+    if (!state.selected) {
+      showStatus('Sélectionnez une sortie DAC.', true);
+      return;
+    }
+    const num = ExampleUtils.normaliseNumber(value);
+    if (num === null) {
+      showStatus('Valeur invalide.', true);
+      return;
+    }
+    try {
+      showStatus('Envoi en cours…');
+      await ExampleUtils.sendOutputValue(state.selected, num);
+      showStatus('Consigne appliquée.');
+      await refreshValues();
+    } catch (err) {
+      showStatus(err.message || 'Échec de l’envoi.', true);
+    }
+  }
+
+  function handleSendClick() {
+    sendValue(inputEl.value);
+  }
+
+  function handleZeroClick() {
+    rangeEl.value = '0';
+    inputEl.value = '0';
+    sendValue(0);
+  }
+
+  function handleFullScaleClick() {
+    const entry = state.entries.find(e => e.name === state.selected);
+    if (!entry) {
+      sendValue(0);
+      return;
+    }
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    if (!Number.isFinite(gain) || gain === 0) {
+      sendValue(0);
+      return;
+    }
+    const target = (4095 - offset) / gain;
+    rangeEl.value = clamp(target, Number(rangeEl.min), Number(rangeEl.max));
+    inputEl.value = target.toFixed(3);
+    sendValue(target);
+  }
+
+  function handleRangeInput() {
+    markEditing();
+    inputEl.value = parseFloat(rangeEl.value).toFixed(3);
+  }
+
+  function handleNumberInput() {
+    markEditing();
+    const num = ExampleUtils.normaliseNumber(inputEl.value);
+    if (num !== null) {
+      const clamped = clamp(num, Number(rangeEl.min), Number(rangeEl.max));
+      rangeEl.value = clamped;
+    }
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.outputsByType(cfg, 'mcp4725');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucune sortie DAC active';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      showStatus('Activez une sortie DAC dans la configuration.', true);
+      updateInfo(null);
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      opt.textContent = entry.name;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  sendBtn.addEventListener('click', handleSendClick);
+  zeroBtn.addEventListener('click', handleZeroClick);
+  fullScaleBtn.addEventListener('click', handleFullScaleClick);
+  rangeEl.addEventListener('input', handleRangeInput);
+  inputEl.addEventListener('input', handleNumberInput);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      showStatus(err.message || 'Authentification requise', true);
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/output-pwm010.html
+++ b/data/examples/output-pwm010.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Exemple – Sortie PWM → 0–10 V</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; max-width: 780px; }
+    h1 { margin-top: 0; }
+    .controls { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin-bottom: 1em; }
+    select { padding: 0.3em; }
+    .panel { border: 1px solid #d0d7e2; border-radius: 8px; padding: 1em; background: #fdfefe; margin-bottom: 1em; }
+    .panel h2 { margin-top: 0; font-size: 1.05em; }
+    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75em; }
+    .metric { background: #f3f7ff; border-radius: 6px; padding: 0.75em; }
+    .metric span { display: block; font-size: 0.85em; color: #4b5874; }
+    .metric strong { font-size: 1.4em; }
+    code { background: #eef2f8; padding: 0.2em 0.4em; border-radius: 4px; }
+    .hint { font-size: 0.95em; color: #34495e; }
+    .status { font-size: 0.9em; min-height: 1.2em; }
+    .status.ok { color: #2c3e50; }
+    .status:not(.ok) { color: #c0392b; }
+    .range-control { display: flex; align-items: center; gap: 0.75em; flex-wrap: wrap; }
+    .range-control input[type="range"] { flex: 1 1 240px; }
+    .range-control input[type="number"] { width: 100px; }
+    .badge { display: inline-flex; align-items: center; gap: 0.3em; font-size: 0.85em; padding: 0.2em 0.5em; border-radius: 999px; background: #ecf0f6; color: #34495e; }
+    .badge.active { background: #e8f8f0; color: #2f7a40; }
+    .actions { display: flex; gap: 0.5em; }
+    button { padding: 0.4em 0.9em; font-size: 1em; }
+  </style>
+  <script src="../auth.js"></script>
+  <script src="utils.js"></script>
+</head>
+<body>
+<h1>Exemple – Sortie PWM → 0–10 V</h1>
+<p class="hint">Cette page pilote une sortie configurée en <strong>PWM → 0–10 V</strong>. Le MiniLabBox convertit votre consigne (en volts ou autre unité) en un rapport cyclique 10 bits (0–1023) pour le convertisseur analogique.</p>
+
+<div class="controls">
+  <label for="outputSelect">Sortie PWM&nbsp;:</label>
+  <select id="outputSelect"></select>
+  <span class="status" id="status"></span>
+</div>
+
+<div class="panel">
+  <h2>Détails de la sortie</h2>
+  <p class="hint">Tag JSON&nbsp;: <code id="tagName">—</code></p>
+  <p class="hint">Échelle / Décalage&nbsp;: <span id="scaleInfo">—</span></p>
+  <p class="hint">Fréquence PWM&nbsp;: <span id="freqInfo">—</span></p>
+  <p class="hint">État&nbsp;: <span class="badge" id="activeBadge">—</span></p>
+</div>
+
+<div class="panel">
+  <h2>Envoyer une consigne</h2>
+  <div class="range-control">
+    <label for="valueRange">Consigne (typ. 0–10 V)&nbsp;:</label>
+    <input type="range" id="valueRange" min="0" max="10" step="0.1" value="0">
+    <input type="number" id="valueInput" step="0.1" value="0">
+    <div class="actions">
+      <button id="sendBtn" type="button">Appliquer</button>
+      <button id="zeroBtn" type="button">Mettre à 0</button>
+    </div>
+  </div>
+</div>
+
+<div class="panel">
+  <h2>Consigne appliquée</h2>
+  <div class="metrics">
+    <div class="metric">
+      <span>Valeur envoyée</span>
+      <strong id="currentValue">—</strong>
+      <span id="unitHint">Unité définie dans la configuration</span>
+    </div>
+    <div class="metric">
+      <span>Rapport cyclique (bits)</span>
+      <strong id="rawBits">—</strong>
+      <span>0 à 1023</span>
+    </div>
+  </div>
+</div>
+
+<p class="hint">Astuce : pour un convertisseur standard, l’échelle vaut environ <code>102.3</code> (1023 bits / 10 V). Ajustez la consigne numérique pour tester rapidement votre actionneur.</p>
+
+<script>
+(function() {
+  'use strict';
+
+  const state = {
+    entries: [],
+    selected: null,
+    timer: null,
+    values: {},
+    editing: false,
+    editTimeout: null
+  };
+
+  const selectEl = document.getElementById('outputSelect');
+  const statusEl = document.getElementById('status');
+  const tagEl = document.getElementById('tagName');
+  const scaleEl = document.getElementById('scaleInfo');
+  const freqEl = document.getElementById('freqInfo');
+  const activeBadge = document.getElementById('activeBadge');
+  const rangeEl = document.getElementById('valueRange');
+  const inputEl = document.getElementById('valueInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const zeroBtn = document.getElementById('zeroBtn');
+  const currentValueEl = document.getElementById('currentValue');
+  const rawBitsEl = document.getElementById('rawBits');
+  const unitHintEl = document.getElementById('unitHint');
+
+  function showStatus(message, isError = false) {
+    statusEl.textContent = message || '';
+    if (!message) {
+      statusEl.classList.remove('ok');
+      return;
+    }
+    if (isError) {
+      statusEl.classList.remove('ok');
+    } else {
+      statusEl.classList.add('ok');
+    }
+  }
+
+  function stopTimer() {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function clearEditingSoon() {
+    if (state.editTimeout) {
+      clearTimeout(state.editTimeout);
+    }
+    state.editTimeout = setTimeout(() => {
+      state.editing = false;
+    }, 1500);
+  }
+
+  function markEditing() {
+    state.editing = true;
+    clearEditingSoon();
+  }
+
+  function updateInfo(entry) {
+    if (!entry) {
+      tagEl.textContent = '—';
+      scaleEl.textContent = '—';
+      freqEl.textContent = '—';
+      activeBadge.textContent = '—';
+      activeBadge.classList.remove('active');
+      rangeEl.disabled = true;
+      inputEl.disabled = true;
+      sendBtn.disabled = true;
+      zeroBtn.disabled = true;
+      unitHintEl.textContent = 'Unité définie dans la configuration';
+      return;
+    }
+    tagEl.textContent = entry.name;
+    const gain = ExampleUtils.normaliseNumber(entry.scale);
+    const offset = ExampleUtils.normaliseNumber(entry.offset) ?? 0;
+    scaleEl.textContent = `${gain ?? '—'} / ${offset}`;
+    const freq = ExampleUtils.normaliseNumber(entry.pwmFreq);
+    freqEl.textContent = freq ? `${freq} Hz` : 'Fréquence par défaut (≈2000 Hz)';
+    rangeEl.disabled = false;
+    inputEl.disabled = false;
+    sendBtn.disabled = false;
+    zeroBtn.disabled = false;
+    unitHintEl.textContent = 'Unité définie dans la configuration';
+  }
+
+  function applyActiveBadge(data) {
+    if (!data) {
+      activeBadge.textContent = '—';
+      activeBadge.classList.remove('active');
+      return;
+    }
+    if (data.active) {
+      activeBadge.textContent = 'Sortie active';
+      activeBadge.classList.add('active');
+    } else {
+      activeBadge.textContent = 'Sortie désactivée';
+      activeBadge.classList.remove('active');
+    }
+  }
+
+  function clamp(value, min, max) {
+    if (!Number.isFinite(value)) return value;
+    if (Number.isFinite(min) && value < min) return min;
+    if (Number.isFinite(max) && value > max) return max;
+    return value;
+  }
+
+  function updateControlsFromValue(value) {
+    const num = ExampleUtils.normaliseNumber(value);
+    if (num === null) {
+      return;
+    }
+    const clamped = clamp(num, Number(rangeEl.min), Number(rangeEl.max));
+    rangeEl.value = clamped;
+    inputEl.value = num.toFixed(2);
+  }
+
+  function updateDisplay() {
+    if (!state.selected) {
+      currentValueEl.textContent = '—';
+      rawBitsEl.textContent = '—';
+      applyActiveBadge(null);
+      return;
+    }
+    const entry = state.entries.find(e => e.name === state.selected);
+    const measurement = state.values[state.selected];
+    const current = measurement ? measurement.value : null;
+    currentValueEl.textContent = ExampleUtils.formatNumber(current, 2);
+    applyActiveBadge(measurement);
+    if (entry) {
+      const raw = ExampleUtils.applyOutputScale(current, entry.scale, entry.offset);
+      rawBitsEl.textContent = raw === null ? '—' : raw.toFixed(0);
+      if (!state.editing) {
+        updateControlsFromValue(current);
+      }
+    } else {
+      rawBitsEl.textContent = '—';
+    }
+  }
+
+  async function refreshValues() {
+    try {
+      const map = await ExampleUtils.fetchOutputsValues();
+      state.values = map;
+      updateDisplay();
+      showStatus('');
+    } catch (err) {
+      showStatus(err.message || 'Erreur de lecture', true);
+    }
+  }
+
+  function handleSelectChange() {
+    state.selected = selectEl.value || null;
+    const entry = state.entries.find(e => e.name === state.selected);
+    updateInfo(entry);
+    updateDisplay();
+  }
+
+  async function sendValue(value) {
+    if (!state.selected) {
+      showStatus('Sélectionnez une sortie PWM.', true);
+      return;
+    }
+    const num = ExampleUtils.normaliseNumber(value);
+    if (num === null) {
+      showStatus('Valeur invalide.', true);
+      return;
+    }
+    try {
+      showStatus('Envoi en cours…');
+      await ExampleUtils.sendOutputValue(state.selected, num);
+      showStatus('Consigne appliquée.');
+      await refreshValues();
+    } catch (err) {
+      showStatus(err.message || 'Échec de l’envoi.', true);
+    }
+  }
+
+  function handleSendClick() {
+    sendValue(inputEl.value);
+  }
+
+  function handleZeroClick() {
+    rangeEl.value = '0';
+    inputEl.value = '0';
+    sendValue(0);
+  }
+
+  function handleRangeInput() {
+    markEditing();
+    inputEl.value = parseFloat(rangeEl.value).toFixed(2);
+  }
+
+  function handleNumberInput() {
+    markEditing();
+    const num = ExampleUtils.normaliseNumber(inputEl.value);
+    if (num !== null) {
+      const clamped = clamp(num, Number(rangeEl.min), Number(rangeEl.max));
+      rangeEl.value = clamped;
+    }
+  }
+
+  async function init() {
+    const cfg = await ExampleUtils.loadConfig();
+    state.entries = ExampleUtils.outputsByType(cfg, 'pwm010');
+    selectEl.innerHTML = '';
+    if (!state.entries.length) {
+      const opt = document.createElement('option');
+      opt.textContent = 'Aucune sortie PWM active';
+      opt.value = '';
+      selectEl.appendChild(opt);
+      selectEl.disabled = true;
+      showStatus('Activez une sortie PWM dans la configuration.', true);
+      updateInfo(null);
+      return;
+    }
+    state.entries.forEach(entry => {
+      const opt = document.createElement('option');
+      opt.value = entry.name;
+      opt.textContent = entry.name;
+      selectEl.appendChild(opt);
+    });
+    selectEl.disabled = false;
+    state.selected = state.entries[0].name;
+    selectEl.value = state.selected;
+    updateInfo(state.entries[0]);
+    await refreshValues();
+    stopTimer();
+    state.timer = setInterval(refreshValues, 1000);
+  }
+
+  selectEl.addEventListener('change', handleSelectChange);
+  sendBtn.addEventListener('click', handleSendClick);
+  zeroBtn.addEventListener('click', handleZeroClick);
+  rangeEl.addEventListener('input', handleRangeInput);
+  inputEl.addEventListener('input', handleNumberInput);
+  window.addEventListener('beforeunload', stopTimer);
+
+  ensureSession()
+    .then(init)
+    .catch(err => {
+      showStatus(err.message || 'Authentification requise', true);
+    });
+})();
+</script>
+</body>
+</html>

--- a/data/examples/utils.js
+++ b/data/examples/utils.js
@@ -1,0 +1,149 @@
+(function() {
+  'use strict';
+
+  async function loadConfig() {
+    const resp = await authFetch('/api/config/get');
+    if (!resp.ok) {
+      throw new Error('Impossible de charger la configuration');
+    }
+    return resp.json();
+  }
+
+  function normaliseNumber(value) {
+    if (value === null || value === undefined) return null;
+    const num = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(num) ? num : null;
+  }
+
+  function mapInputsByType(cfg, type) {
+    if (!cfg || !Array.isArray(cfg.inputs)) return [];
+    return cfg.inputs
+      .filter(item => item && item.type === type && item.active)
+      .map(item => ({
+        name: item.name,
+        unit: item.unit || '',
+        scale: normaliseNumber(item.scale) ?? 1,
+        offset: normaliseNumber(item.offset) ?? 0,
+        pin: item.pin || '',
+        adsChannel: item.adsChannel,
+        remoteNode: item.remoteNode || '',
+        remoteName: item.remoteName || ''
+      }));
+  }
+
+  function mapOutputsByType(cfg, type) {
+    if (!cfg || !Array.isArray(cfg.outputs)) return [];
+    return cfg.outputs
+      .filter(item => item && item.type === type && item.active)
+      .map(item => ({
+        name: item.name,
+        scale: normaliseNumber(item.scale) ?? 1,
+        offset: normaliseNumber(item.offset) ?? 0,
+        pwmFreq: item.pwmFreq,
+        i2cAddress: item.i2cAddress || ''
+      }));
+  }
+
+  async function fetchInputsValues() {
+    const resp = await authFetch('/api/inputs');
+    if (!resp.ok) {
+      throw new Error('Lecture des entrées impossible');
+    }
+    const data = await resp.json();
+    const result = {};
+    if (data && Array.isArray(data.inputs)) {
+      data.inputs.forEach(entry => {
+        if (entry && entry.name) {
+          result[entry.name] = normaliseNumber(entry.value);
+        }
+      });
+    }
+    return result;
+  }
+
+  async function fetchOutputsValues() {
+    const resp = await authFetch('/api/outputs');
+    if (!resp.ok) {
+      throw new Error('Lecture des sorties impossible');
+    }
+    const data = await resp.json();
+    const result = {};
+    if (data && Array.isArray(data.outputs)) {
+      data.outputs.forEach(entry => {
+        if (entry && entry.name) {
+          result[entry.name] = {
+            value: normaliseNumber(entry.value),
+            active: !!entry.active
+          };
+        }
+      });
+    }
+    return result;
+  }
+
+  async function sendOutputValue(name, value) {
+    const payload = JSON.stringify({ name, value });
+    const resp = await authFetch('/api/output/set', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text || 'Écriture de sortie refusée');
+    }
+    return resp.json().catch(() => ({}));
+  }
+
+  function computeRawValue(value, scale, offset) {
+    const val = normaliseNumber(value);
+    const gain = normaliseNumber(scale);
+    const off = normaliseNumber(offset) ?? 0;
+    if (val === null || gain === null || gain === 0) {
+      return null;
+    }
+    const raw = (val - off) / gain;
+    return Number.isFinite(raw) ? raw : null;
+  }
+
+  function applyOutputScale(value, scale, offset) {
+    const val = normaliseNumber(value);
+    const gain = normaliseNumber(scale);
+    const off = normaliseNumber(offset) ?? 0;
+    if (val === null || gain === null) {
+      return null;
+    }
+    const raw = val * gain + off;
+    return Number.isFinite(raw) ? raw : null;
+  }
+
+  function slugFromName(name) {
+    if (!name) return '';
+    return name.toString().trim().toLowerCase().normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
+
+  function formatNumber(value, digits = 3) {
+    const num = normaliseNumber(value);
+    if (num === null) {
+      return '—';
+    }
+    return num.toFixed(digits);
+  }
+
+  window.ExampleUtils = {
+    loadConfig,
+    inputsByType: mapInputsByType,
+    outputsByType: mapOutputsByType,
+    fetchInputsValues,
+    fetchOutputsValues,
+    sendOutputValue,
+    computeRawValue,
+    applyOutputScale,
+    normaliseNumber,
+    slugFromName,
+    formatNumber
+  };
+})();


### PR DESCRIPTION
## Summary
- enrich the configuration modal with contextual information, ranges and tag hints for each IO type
- add a shared example utility module and dedicated example pages for each supported input and output
- document the PWM, GPIO and MCP4725 control flows with interactive output demos

## Testing
- Not run (static web assets)


------
https://chatgpt.com/codex/tasks/task_e_68cbd8d1e3e4832e84f25ea6926d49a1