### PR TITLE
Implement virtual lab workspace for virtual instruments

### DIFF
--- a/src/virtual_lab/DidacticMenu.cpp
+++ b/src/virtual_lab/DidacticMenu.cpp
@@ -1,0 +1,33 @@
+#include "virtual_lab/DidacticMenu.h"
+
+namespace virtual_lab {
+
+void DidacticMenu::addEntry(const String &key, const String &title,
+                            const String &text) {
+  for (auto &entry : entries_) {
+    if (entry.key == key) {
+      entry.title = title;
+      entry.text = text;
+      return;
+    }
+  }
+  DidacticEntry entry;
+  entry.key = key;
+  entry.title = title;
+  entry.text = text;
+  entries_.push_back(entry);
+}
+
+bool DidacticMenu::findEntry(const String &key, DidacticEntry &entry) const {
+  for (const auto &item : entries_) {
+    if (item.key == key) {
+      entry = item;
+      return true;
+    }
+  }
+  return false;
+}
+
+void DidacticMenu::clear() { entries_.clear(); }
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/DidacticMenu.h
+++ b/src/virtual_lab/DidacticMenu.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Arduino.h>
+#include <vector>
+
+namespace virtual_lab {
+
+struct DidacticEntry {
+  String key;
+  String title;
+  String text;
+};
+
+class DidacticMenu {
+ public:
+  void addEntry(const String &key, const String &title, const String &text);
+  bool findEntry(const String &key, DidacticEntry &entry) const;
+  void clear();
+  const std::vector<DidacticEntry> &entries() const { return entries_; }
+
+ private:
+  std::vector<DidacticEntry> entries_;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/FunctionGenerator.cpp
+++ b/src/virtual_lab/FunctionGenerator.cpp
@@ -1,0 +1,105 @@
+#include "virtual_lab/FunctionGenerator.h"
+
+#include "virtual_lab/DidacticMenu.h"
+#include "virtual_lab/VirtualWorkspace.h"
+
+namespace virtual_lab {
+
+FunctionGenerator::FunctionGenerator(VirtualWorkspace &workspace)
+    : workspace_(workspace) {}
+
+FunctionGenerator::Output *FunctionGenerator::findOutput(const String &id) {
+  for (auto &output : outputs_) {
+    if (output.id == id) {
+      return &output;
+    }
+  }
+  return nullptr;
+}
+
+const FunctionGenerator::Output *FunctionGenerator::findOutput(
+    const String &id) const {
+  for (const auto &output : outputs_) {
+    if (output.id == id) {
+      return &output;
+    }
+  }
+  return nullptr;
+}
+
+bool FunctionGenerator::configureOutput(
+    const FunctionGeneratorOutputConfig &config, String &error) {
+  error = "";
+  if (config.id.length() == 0) {
+    error = "missing_id";
+    return false;
+  }
+  if (config.name.length() == 0) {
+    error = "missing_name";
+    return false;
+  }
+  auto *existing = findOutput(config.id);
+  if (existing) {
+    existing->name = config.name;
+    existing->settings = config.settings;
+    existing->enabled = config.enabled;
+    existing->units = config.units;
+    if (existing->signal) {
+      existing->signal->setName(config.name);
+      existing->signal->configure(config.settings);
+      existing->signal->setUnits(config.units);
+    }
+    return true;
+  }
+  auto signal = std::make_shared<WaveformSignal>(config.id, config.name);
+  signal->configure(config.settings);
+  signal->setUnits(config.units.length() ? config.units : String("V"));
+  signal->setHelpKey("function_generator.output");
+  if (!workspace_.registerSignal(signal)) {
+    error = "duplicate_signal";
+    return false;
+  }
+  Output output;
+  output.id = config.id;
+  output.name = config.name;
+  output.enabled = config.enabled;
+  output.settings = config.settings;
+  output.units = signal->units();
+  output.signal = signal;
+  outputs_.push_back(output);
+  return true;
+}
+
+bool FunctionGenerator::removeOutput(const String &id) {
+  for (size_t i = 0; i < outputs_.size(); ++i) {
+    if (outputs_[i].id == id) {
+      workspace_.removeSignal(outputs_[i].id);
+      outputs_.erase(outputs_.begin() + i);
+      return true;
+    }
+  }
+  return false;
+}
+
+void FunctionGenerator::disableAll() {
+  for (auto &output : outputs_) {
+    output.enabled = false;
+  }
+}
+
+void FunctionGenerator::populateHelp(DidacticMenu &menu) const {
+  menu.addEntry(
+      "function_generator.overview", "Générateur de fonctions",
+      "Configurez des sorties virtuelles sinusoïdales, carrées, triangulaires, "
+      "dent de scie ou bruit blanc. Chaque sortie peut être reliée à des "
+      "équations mathématiques ou à des instruments. Réglez amplitude, "
+      "fréquence, décalage et facteur de service pour explorer différents "
+      "signaux pédagogiques.");
+  menu.addEntry(
+      "function_generator.output", "Sortie du générateur",
+      "Une sortie virtuelle peut être utilisée par l'oscilloscope ou le "
+      "multimètre. Activez ou désactivez la sortie selon le scénario "
+      "pédagogique souhaité.");
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/FunctionGenerator.h
+++ b/src/virtual_lab/FunctionGenerator.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Arduino.h>
+#include <memory>
+#include <vector>
+
+#include "virtual_lab/VirtualSignal.h"
+
+namespace virtual_lab {
+
+class VirtualWorkspace;
+class DidacticMenu;
+
+struct FunctionGeneratorOutputConfig {
+  String id;
+  String name;
+  WaveformSettings settings;
+  bool enabled = true;
+  String units;
+};
+
+class FunctionGenerator {
+ public:
+  explicit FunctionGenerator(VirtualWorkspace &workspace);
+
+  bool configureOutput(const FunctionGeneratorOutputConfig &config,
+                       String &error);
+  bool removeOutput(const String &id);
+  void disableAll();
+
+  struct Output {
+    String id;
+    String name;
+    bool enabled = true;
+    WaveformSettings settings;
+    String units;
+    std::shared_ptr<WaveformSignal> signal;
+  };
+
+  const std::vector<Output> &outputs() const { return outputs_; }
+
+  void populateHelp(DidacticMenu &menu) const;
+
+ private:
+  VirtualWorkspace &workspace_;
+  std::vector<Output> outputs_;
+
+  Output *findOutput(const String &id);
+  const Output *findOutput(const String &id) const;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/MathExpression.cpp
+++ b/src/virtual_lab/MathExpression.cpp
@@ -1,0 +1,511 @@
+#include "virtual_lab/MathExpression.h"
+
+#include <algorithm>
+#include <ctype.h>
+#include <math.h>
+#include <stdlib.h>
+
+#ifndef M_E
+#define M_E 2.71828182845904523536
+#endif
+
+namespace virtual_lab {
+
+namespace {
+
+struct Node {
+  enum class Type { Constant, Variable, Unary, Binary, Function };
+  Type type;
+  float constant = 0.0f;
+  char op = '\0';
+  String identifier;
+  std::vector<std::unique_ptr<Node>> children;
+};
+
+class Parser {
+ public:
+  Parser(const std::string &source, MathExpression *owner, String &error)
+      : source_(source), owner_(owner), error_(error) {}
+
+  std::unique_ptr<Node> parse() {
+    skipWhitespace();
+    auto expr = parseExpression();
+    skipWhitespace();
+    if (!expr || hasError()) {
+      return nullptr;
+    }
+    if (position_ != source_.size()) {
+      setError(String("Unexpected token at position ") + String(position_ + 1));
+      return nullptr;
+    }
+    return expr;
+  }
+
+ private:
+  std::unique_ptr<Node> parseExpression() {
+    auto node = parseTerm();
+    if (!node) return nullptr;
+    while (true) {
+      skipWhitespace();
+      if (match('+')) {
+        auto rhs = parseTerm();
+        if (!rhs) return nullptr;
+        node = makeBinary('+', std::move(node), std::move(rhs));
+      } else if (match('-')) {
+        auto rhs = parseTerm();
+        if (!rhs) return nullptr;
+        node = makeBinary('-', std::move(node), std::move(rhs));
+      } else {
+        break;
+      }
+    }
+    return node;
+  }
+
+  std::unique_ptr<Node> parseTerm() {
+    auto node = parsePower();
+    if (!node) return nullptr;
+    while (true) {
+      skipWhitespace();
+      if (match('*')) {
+        auto rhs = parsePower();
+        if (!rhs) return nullptr;
+        node = makeBinary('*', std::move(node), std::move(rhs));
+      } else if (match('/')) {
+        auto rhs = parsePower();
+        if (!rhs) return nullptr;
+        node = makeBinary('/', std::move(node), std::move(rhs));
+      } else {
+        break;
+      }
+    }
+    return node;
+  }
+
+  std::unique_ptr<Node> parsePower() {
+    auto node = parseUnary();
+    if (!node) return nullptr;
+    skipWhitespace();
+    if (match('^')) {
+      auto rhs = parsePower();
+      if (!rhs) return nullptr;
+      node = makeBinary('^', std::move(node), std::move(rhs));
+    }
+    return node;
+  }
+
+  std::unique_ptr<Node> parseUnary() {
+    skipWhitespace();
+    if (match('+')) {
+      return parseUnary();
+    }
+    if (match('-')) {
+      auto operand = parseUnary();
+      if (!operand) return nullptr;
+      auto node = std::unique_ptr<Node>(new Node());
+      node->type = Node::Type::Unary;
+      node->op = '-';
+      node->children.push_back(std::move(operand));
+      return node;
+    }
+    return parsePrimary();
+  }
+
+  std::unique_ptr<Node> parsePrimary() {
+    skipWhitespace();
+    if (match('(')) {
+      auto node = parseExpression();
+      if (!node) return nullptr;
+      skipWhitespace();
+      if (!match(')')) {
+        setError(String("Missing closing parenthesis at position ") +
+                 String(position_ + 1));
+        return nullptr;
+      }
+      return node;
+    }
+
+    if (peek() == '\0') {
+      setError("Unexpected end of expression");
+      return nullptr;
+    }
+
+    if (isdigit(peek()) || peek() == '.') {
+      return parseNumber();
+    }
+
+    if (isalpha(peek()) || peek() == '_') {
+      return parseIdentifier();
+    }
+
+    setError(String("Unexpected character '") + String(peek()) + "'");
+    return nullptr;
+  }
+
+  std::unique_ptr<Node> parseNumber() {
+    const char *start = source_.c_str() + position_;
+    char *end = nullptr;
+    double value = strtod(start, &end);
+    if (end == start) {
+      setError(String("Invalid number at position ") + String(position_ + 1));
+      return nullptr;
+    }
+    position_ = static_cast<size_t>(end - source_.c_str());
+    auto node = std::unique_ptr<Node>(new Node());
+    node->type = Node::Type::Constant;
+    node->constant = static_cast<float>(value);
+    return node;
+  }
+
+  std::unique_ptr<Node> parseIdentifier() {
+    size_t start = position_;
+    while (isalnum(peek()) || peek() == '_') {
+      advance();
+    }
+    std::string ident = source_.substr(start, position_ - start);
+    std::string lowered = ident;
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(), ::tolower);
+    skipWhitespace();
+    if (match('(')) {
+      auto node = std::unique_ptr<Node>(new Node());
+      node->type = Node::Type::Function;
+      node->identifier = String(lowered.c_str());
+      if (match(')')) {
+        return node;
+      }
+      while (true) {
+        auto arg = parseExpression();
+        if (!arg) return nullptr;
+        node->children.push_back(std::move(arg));
+        skipWhitespace();
+        if (match(')')) {
+          break;
+        }
+        if (!match(',')) {
+          setError(String("Expected ',' or ')' in argument list at position ") +
+                   String(position_ + 1));
+          return nullptr;
+        }
+      }
+      return node;
+    }
+
+    if (lowered == "pi") {
+      auto node = std::unique_ptr<Node>(new Node());
+      node->type = Node::Type::Constant;
+      node->constant = PI;
+      return node;
+    }
+    if (lowered == "e") {
+      auto node = std::unique_ptr<Node>(new Node());
+      node->type = Node::Type::Constant;
+      node->constant = static_cast<float>(M_E);
+      return node;
+    }
+
+    auto node = std::unique_ptr<Node>(new Node());
+    node->type = Node::Type::Variable;
+    node->identifier = String(ident.c_str());
+    owner_->registerVariable(node->identifier);
+    return node;
+  }
+
+  bool match(char expected) {
+    if (peek() == expected) {
+      advance();
+      return true;
+    }
+    return false;
+  }
+
+  char peek() const {
+    if (position_ >= source_.size()) {
+      return '\0';
+    }
+    return source_[position_];
+  }
+
+  void advance() {
+    if (position_ < source_.size()) {
+      ++position_;
+    }
+  }
+
+  void skipWhitespace() {
+    while (isspace(peek())) {
+      advance();
+    }
+  }
+
+  bool hasError() const { return error_.length() > 0; }
+
+  void setError(const String &message) {
+    if (error_.length() == 0) {
+      error_ = message;
+    }
+  }
+
+  std::unique_ptr<Node> makeBinary(char op, std::unique_ptr<Node> left,
+                                   std::unique_ptr<Node> right) {
+    auto node = std::unique_ptr<Node>(new Node());
+    node->type = Node::Type::Binary;
+    node->op = op;
+    node->children.push_back(std::move(left));
+    node->children.push_back(std::move(right));
+    return node;
+  }
+
+  const std::string &source_;
+  MathExpression *owner_;
+  String &error_;
+  size_t position_ = 0;
+};
+
+float applyBinary(char op, float lhs, float rhs) {
+  switch (op) {
+    case '+':
+      return lhs + rhs;
+    case '-':
+      return lhs - rhs;
+    case '*':
+      return lhs * rhs;
+    case '/':
+      return rhs == 0.0f ? NAN : lhs / rhs;
+    case '^':
+      return powf(lhs, rhs);
+    default:
+      return NAN;
+  }
+}
+
+float applyUnary(char op, float value) {
+  switch (op) {
+    case '-':
+      return -value;
+    default:
+      return value;
+  }
+}
+
+bool evaluateFunction(const String &name, const std::vector<float> &args,
+                      float &out) {
+  String lower = name;
+  lower.toLowerCase();
+  if (lower == "sin") {
+    if (args.size() != 1) return false;
+    out = sinf(args[0]);
+    return true;
+  }
+  if (lower == "cos") {
+    if (args.size() != 1) return false;
+    out = cosf(args[0]);
+    return true;
+  }
+  if (lower == "tan") {
+    if (args.size() != 1) return false;
+    out = tanf(args[0]);
+    return true;
+  }
+  if (lower == "asin") {
+    if (args.size() != 1) return false;
+    out = asinf(args[0]);
+    return true;
+  }
+  if (lower == "acos") {
+    if (args.size() != 1) return false;
+    out = acosf(args[0]);
+    return true;
+  }
+  if (lower == "atan") {
+    if (args.size() != 1) return false;
+    out = atanf(args[0]);
+    return true;
+  }
+  if (lower == "sqrt") {
+    if (args.size() != 1) return false;
+    out = args[0] < 0.0f ? NAN : sqrtf(args[0]);
+    return true;
+  }
+  if (lower == "abs") {
+    if (args.size() != 1) return false;
+    out = fabsf(args[0]);
+    return true;
+  }
+  if (lower == "exp") {
+    if (args.size() != 1) return false;
+    out = expf(args[0]);
+    return true;
+  }
+  if (lower == "ln" || lower == "log") {
+    if (args.size() != 1) return false;
+    out = args[0] <= 0.0f ? NAN : logf(args[0]);
+    return true;
+  }
+  if (lower == "log10") {
+    if (args.size() != 1) return false;
+    out = args[0] <= 0.0f ? NAN : log10f(args[0]);
+    return true;
+  }
+  if (lower == "floor") {
+    if (args.size() != 1) return false;
+    out = floorf(args[0]);
+    return true;
+  }
+  if (lower == "ceil") {
+    if (args.size() != 1) return false;
+    out = ceilf(args[0]);
+    return true;
+  }
+  if (lower == "round") {
+    if (args.size() != 1) return false;
+    out = roundf(args[0]);
+    return true;
+  }
+  if (lower == "min") {
+    if (args.empty()) return false;
+    float value = args[0];
+    for (size_t i = 1; i < args.size(); ++i) {
+      value = (args[i] < value) ? args[i] : value;
+    }
+    out = value;
+    return true;
+  }
+  if (lower == "max") {
+    if (args.empty()) return false;
+    float value = args[0];
+    for (size_t i = 1; i < args.size(); ++i) {
+      value = (args[i] > value) ? args[i] : value;
+    }
+    out = value;
+    return true;
+  }
+  if (lower == "avg" || lower == "mean") {
+    if (args.empty()) return false;
+    float sum = 0.0f;
+    for (float v : args) sum += v;
+    out = sum / static_cast<float>(args.size());
+    return true;
+  }
+  if (lower == "sum") {
+    float sum = 0.0f;
+    for (float v : args) sum += v;
+    out = sum;
+    return true;
+  }
+  if (lower == "clamp") {
+    if (args.size() != 3) return false;
+    float value = args[0];
+    float lo = args[1];
+    float hi = args[2];
+    if (lo > hi) {
+      float tmp = lo;
+      lo = hi;
+      hi = tmp;
+    }
+    if (value < lo) value = lo;
+    if (value > hi) value = hi;
+    out = value;
+    return true;
+  }
+  if (lower == "pow") {
+    if (args.size() != 2) return false;
+    out = powf(args[0], args[1]);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+MathExpression::MathExpression() = default;
+MathExpression::~MathExpression() = default;
+
+bool MathExpression::compile(const String &expression, String &errorMessage) {
+  expression_ = expression;
+  asciiExpression_ = std::string(expression.c_str());
+  variables_.clear();
+  errorMessage = "";
+  Parser parser(asciiExpression_, this, errorMessage);
+  root_ = parser.parse();
+  if (!root_) {
+    return false;
+  }
+  return true;
+}
+
+bool MathExpression::evaluate(
+    const std::function<bool(const String &, float &)> &resolver,
+    float &out) const {
+  if (!root_) {
+    return false;
+  }
+  return evaluateNode(root_.get(), resolver, out);
+}
+
+void MathExpression::registerVariable(const String &name) {
+  for (const auto &existing : variables_) {
+    if (existing == name) {
+      return;
+    }
+  }
+  variables_.push_back(name);
+}
+
+bool MathExpression::evaluateNode(
+    const Node *node,
+    const std::function<bool(const String &, float &)> &resolver,
+    float &out) const {
+  switch (node->type) {
+    case Node::Type::Constant:
+      out = node->constant;
+      return true;
+    case Node::Type::Variable: {
+      float value = NAN;
+      if (!resolver(node->identifier, value)) {
+        return false;
+      }
+      out = value;
+      return true;
+    }
+    case Node::Type::Unary: {
+      float operand = NAN;
+      if (!evaluateNode(node->children[0].get(), resolver, operand)) {
+        return false;
+      }
+      out = applyUnary(node->op, operand);
+      return true;
+    }
+    case Node::Type::Binary: {
+      float lhs = NAN;
+      float rhs = NAN;
+      if (!evaluateNode(node->children[0].get(), resolver, lhs)) {
+        return false;
+      }
+      if (!evaluateNode(node->children[1].get(), resolver, rhs)) {
+        return false;
+      }
+      out = applyBinary(node->op, lhs, rhs);
+      return true;
+    }
+    case Node::Type::Function: {
+      std::vector<float> args;
+      args.reserve(node->children.size());
+      for (const auto &child : node->children) {
+        float value = NAN;
+        if (!evaluateNode(child.get(), resolver, value)) {
+          return false;
+        }
+        args.push_back(value);
+      }
+      float value = NAN;
+      if (!evaluateFunction(node->identifier, args, value)) {
+        return false;
+      }
+      out = value;
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/MathExpression.h
+++ b/src/virtual_lab/MathExpression.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <Arduino.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace virtual_lab {
+
+class MathExpression {
+ public:
+  MathExpression();
+  ~MathExpression();
+
+  bool compile(const String &expression, String &errorMessage);
+
+  bool evaluate(const std::function<bool(const String &, float &)> &resolver,
+                float &out) const;
+
+  const std::vector<String> &variables() const { return variables_; }
+  const String &expression() const { return expression_; }
+
+ private:
+  struct Node;
+
+  std::unique_ptr<Node> parseExpression(String &errorMessage);
+
+  std::unique_ptr<Node> root_;
+  std::vector<String> variables_;
+  String expression_;
+  std::string asciiExpression_;
+
+  void registerVariable(const String &name);
+
+  bool evaluateNode(const Node *node,
+                    const std::function<bool(const String &, float &)> &resolver,
+                    float &out) const;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/MathZone.cpp
+++ b/src/virtual_lab/MathZone.cpp
@@ -1,0 +1,77 @@
+#include "virtual_lab/MathZone.h"
+
+#include <memory>
+
+#include "virtual_lab/DidacticMenu.h"
+#include "virtual_lab/VirtualWorkspace.h"
+
+namespace virtual_lab {
+
+MathZone::MathZone(VirtualWorkspace &workspace) : workspace_(workspace) {}
+
+bool MathZone::defineExpression(const MathExpressionConfig &config,
+                                String &error) {
+  error = "";
+  if (config.id.length() == 0) {
+    error = "missing_id";
+    return false;
+  }
+  if (config.name.length() == 0) {
+    error = "missing_name";
+    return false;
+  }
+  if (config.expression.length() == 0) {
+    error = "missing_expression";
+    return false;
+  }
+  auto signal = std::make_shared<MathVirtualSignal>(config.id, config.name);
+  String compileError;
+  if (!signal->configure(config.expression, config.bindings, compileError)) {
+    error = String("compile_error:") + compileError;
+    return false;
+  }
+  signal->setUnits(config.units.length() ? config.units : String("V"));
+  signal->setHelpKey("math_zone.expression");
+  if (!workspace_.registerSignal(signal)) {
+    error = "duplicate_signal";
+    return false;
+  }
+  bool found = false;
+  for (auto &id : expressionIds_) {
+    if (id == config.id) {
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    expressionIds_.push_back(config.id);
+  }
+  return true;
+}
+
+bool MathZone::removeExpression(const String &id) {
+  for (size_t i = 0; i < expressionIds_.size(); ++i) {
+    if (expressionIds_[i] == id) {
+      expressionIds_.erase(expressionIds_.begin() + i);
+      workspace_.removeSignal(id);
+      return true;
+    }
+  }
+  return false;
+}
+
+void MathZone::populateHelp(DidacticMenu &menu) const {
+  menu.addEntry(
+      "math_zone.overview", "Zone mathématique",
+      "Créez des équations virtuelles basées sur les signaux disponibles. Les "
+      "fonctions mathématiques standard (sin, cos, min, max, etc.) sont "
+      "disponibles pour composer vos scénarios pédagogiques.");
+  menu.addEntry(
+      "math_zone.expression",
+      "Équation",
+      "Associez un identifiant et une expression. Les variables sont "
+      "résolues dynamiquement sur les signaux existants, sans redémarrage de "
+      "l'équipement.");
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/MathZone.h
+++ b/src/virtual_lab/MathZone.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Arduino.h>
+#include <vector>
+
+#include "virtual_lab/VirtualSignal.h"
+
+namespace virtual_lab {
+
+class VirtualWorkspace;
+class DidacticMenu;
+
+struct MathExpressionConfig {
+  String id;
+  String name;
+  String expression;
+  std::vector<VariableBinding> bindings;
+  String units;
+};
+
+class MathZone {
+ public:
+  explicit MathZone(VirtualWorkspace &workspace);
+
+  bool defineExpression(const MathExpressionConfig &config, String &error);
+  bool removeExpression(const String &id);
+  const std::vector<String> &expressions() const { return expressionIds_; }
+
+  void populateHelp(DidacticMenu &menu) const;
+
+ private:
+  VirtualWorkspace &workspace_;
+  std::vector<String> expressionIds_;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/Multimeter.cpp
+++ b/src/virtual_lab/Multimeter.cpp
@@ -1,0 +1,146 @@
+#include "virtual_lab/Multimeter.h"
+
+#include <math.h>
+
+#include "virtual_lab/DidacticMenu.h"
+#include "virtual_lab/VirtualWorkspace.h"
+
+namespace virtual_lab {
+
+Multimeter::Multimeter(VirtualWorkspace &workspace) : workspace_(workspace) {}
+
+bool Multimeter::configureInput(const MultimeterInputConfig &config) {
+  if (config.id.length() == 0 || config.signalId.length() == 0) {
+    return false;
+  }
+  for (auto &input : inputs_) {
+    if (input.id == config.id) {
+      input = config;
+      return true;
+    }
+  }
+  inputs_.push_back(config);
+  return true;
+}
+
+bool Multimeter::removeInput(const String &id) {
+  for (size_t i = 0; i < inputs_.size(); ++i) {
+    if (inputs_[i].id == id) {
+      inputs_.erase(inputs_.begin() + i);
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool computeSeriesMetrics(const std::vector<float> &samples, float &minValue,
+                                 float &maxValue, float &average, float &rms) {
+  if (samples.empty()) {
+    return false;
+  }
+  minValue = samples[0];
+  maxValue = samples[0];
+  double sum = 0.0;
+  double squareSum = 0.0;
+  for (float value : samples) {
+    if (value < minValue) minValue = value;
+    if (value > maxValue) maxValue = value;
+    sum += value;
+    squareSum += static_cast<double>(value) * static_cast<double>(value);
+  }
+  average = static_cast<float>(sum / static_cast<double>(samples.size()));
+  rms = static_cast<float>(sqrt(squareSum / static_cast<double>(samples.size())));
+  return true;
+}
+
+bool Multimeter::measure(const MultimeterMeasurementRequest &request,
+                         MultimeterMeasurementResult &result,
+                         String &error) const {
+  error = "";
+  result.inputId = request.inputId;
+  result.mode = request.mode;
+  const MultimeterInputConfig *selected = nullptr;
+  for (const auto &input : inputs_) {
+    if (input.id == request.inputId) {
+      selected = &input;
+      break;
+    }
+  }
+  if (!selected) {
+    error = String("unknown_input_") + request.inputId;
+    return false;
+  }
+  if (!selected->enabled) {
+    error = String("input_disabled_") + request.inputId;
+    return false;
+  }
+  if (request.sampleRate <= 0.0f || request.sampleCount == 0) {
+    error = "invalid_sampling";
+    return false;
+  }
+  float interval = 1.0f / request.sampleRate;
+  std::vector<float> samples;
+  samples.reserve(request.sampleCount);
+  for (size_t i = 0; i < request.sampleCount; ++i) {
+    float time = request.startTime + interval * static_cast<float>(i);
+    float value = NAN;
+    if (!workspace_.sampleSignal(selected->signalId, time, value)) {
+      error = String("missing_signal_") + selected->signalId;
+      return false;
+    }
+    samples.push_back(value);
+  }
+  float minValue = NAN;
+  float maxValue = NAN;
+  float average = NAN;
+  float rms = NAN;
+  if (!computeSeriesMetrics(samples, minValue, maxValue, average, rms)) {
+    error = "metrics_failed";
+    return false;
+  }
+  switch (request.mode) {
+    case MultimeterMode::DC:
+      result.value = average;
+      break;
+    case MultimeterMode::AC_RMS: {
+      float acComponentRms = 0.0f;
+      double sum = 0.0;
+      for (float v : samples) {
+        double deviation = static_cast<double>(v) - static_cast<double>(average);
+        sum += deviation * deviation;
+      }
+      acComponentRms = static_cast<float>(sqrt(sum / samples.size()));
+      result.value = acComponentRms;
+      break;
+    }
+    case MultimeterMode::MIN:
+      result.value = minValue;
+      break;
+    case MultimeterMode::MAX:
+      result.value = maxValue;
+      break;
+    case MultimeterMode::AVERAGE:
+      result.value = average;
+      break;
+    case MultimeterMode::PEAK_TO_PEAK:
+      result.value = maxValue - minValue;
+      break;
+  }
+  result.minValue = minValue;
+  result.maxValue = maxValue;
+  return true;
+}
+
+void Multimeter::populateHelp(DidacticMenu &menu) const {
+  menu.addEntry("multimeter.overview", "Multimètre virtuel",
+                "Mesurez des grandeurs continues ou alternatives sur les "
+                "signaux disponibles. Sélectionnez la fonction souhaitée : DC, "
+                "RMS, min, max, moyenne ou crête à crête.");
+  menu.addEntry(
+      "multimeter.inputs", "Entrées du multimètre",
+      "Chaque entrée virtuelle peut être reliée à une source mathématique ou "
+      "physique simulée. Les mesures sont réalisées sans nécessiter de "
+      "redémarrage du système.");
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/Multimeter.h
+++ b/src/virtual_lab/Multimeter.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <Arduino.h>
+#include <vector>
+
+namespace virtual_lab {
+
+class VirtualWorkspace;
+class DidacticMenu;
+
+struct MultimeterInputConfig {
+  String id;
+  String signalId;
+  String label;
+  bool enabled = true;
+};
+
+enum class MultimeterMode {
+  DC,
+  AC_RMS,
+  MIN,
+  MAX,
+  AVERAGE,
+  PEAK_TO_PEAK
+};
+
+struct MultimeterMeasurementRequest {
+  String inputId;
+  MultimeterMode mode = MultimeterMode::DC;
+  float startTime = 0.0f;
+  float sampleRate = 500.0f;
+  size_t sampleCount = 128;
+};
+
+struct MultimeterMeasurementResult {
+  String inputId;
+  MultimeterMode mode = MultimeterMode::DC;
+  float value = NAN;
+  float minValue = NAN;
+  float maxValue = NAN;
+};
+
+class Multimeter {
+ public:
+  explicit Multimeter(VirtualWorkspace &workspace);
+
+  bool configureInput(const MultimeterInputConfig &config);
+  bool removeInput(const String &id);
+  const std::vector<MultimeterInputConfig> &inputs() const { return inputs_; }
+
+  bool measure(const MultimeterMeasurementRequest &request,
+               MultimeterMeasurementResult &result,
+               String &error) const;
+
+  void populateHelp(DidacticMenu &menu) const;
+
+ private:
+  VirtualWorkspace &workspace_;
+  std::vector<MultimeterInputConfig> inputs_;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/Oscilloscope.cpp
+++ b/src/virtual_lab/Oscilloscope.cpp
@@ -1,0 +1,83 @@
+#include "virtual_lab/Oscilloscope.h"
+
+#include "virtual_lab/DidacticMenu.h"
+#include "virtual_lab/VirtualSignal.h"
+#include "virtual_lab/VirtualWorkspace.h"
+
+namespace virtual_lab {
+
+Oscilloscope::Oscilloscope(VirtualWorkspace &workspace)
+    : workspace_(workspace) {}
+
+bool Oscilloscope::configureTrace(const OscilloscopeTraceConfig &config) {
+  if (config.id.length() == 0 || config.signalId.length() == 0) {
+    return false;
+  }
+  for (auto &trace : traces_) {
+    if (trace.id == config.id) {
+      trace = config;
+      return true;
+    }
+  }
+  traces_.push_back(config);
+  return true;
+}
+
+bool Oscilloscope::removeTrace(const String &id) {
+  for (size_t i = 0; i < traces_.size(); ++i) {
+    if (traces_[i].id == id) {
+      traces_.erase(traces_.begin() + i);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Oscilloscope::capture(const OscilloscopeCaptureRequest &request,
+                           OscilloscopeCaptureResult &result,
+                           String &error) const {
+  error = "";
+  if (request.sampleRate <= 0.0f || request.sampleCount == 0) {
+    error = "invalid_sampling";
+    return false;
+  }
+  float interval = 1.0f / request.sampleRate;
+  result.sampleRate = request.sampleRate;
+  result.traces.clear();
+  for (const auto &trace : traces_) {
+    if (!trace.enabled) {
+      continue;
+    }
+    OscilloscopeTraceData data;
+    data.id = trace.id;
+    data.label = trace.label;
+    data.enabled = trace.enabled;
+    data.samples.reserve(request.sampleCount);
+    for (size_t i = 0; i < request.sampleCount; ++i) {
+      float time = request.startTime + interval * static_cast<float>(i);
+      float value = NAN;
+      if (!workspace_.sampleSignal(trace.signalId, time, value)) {
+        error = String("missing_signal_") + trace.signalId;
+        return false;
+      }
+      data.samples.push_back(value);
+    }
+    result.traces.push_back(data);
+  }
+  return true;
+}
+
+void Oscilloscope::populateHelp(DidacticMenu &menu) const {
+  menu.addEntry(
+      "oscilloscope.overview", "Oscilloscope virtuel",
+      "Affichez plusieurs traces simultanément. La base de temps est définie "
+      "par la fréquence d'échantillonnage. Configurez les canaux pour "
+      "observer les signaux générés ou calculés.");
+  menu.addEntry(
+      "oscilloscope.trigger",
+      "Capture", "Chaque acquisition retourne un ensemble d'échantillons "
+                  "pour les traces actives. Les données peuvent être "
+                  "transmises via l'API pour affichage dans l'interface.");
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/Oscilloscope.h
+++ b/src/virtual_lab/Oscilloscope.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <Arduino.h>
+#include <vector>
+
+namespace virtual_lab {
+
+class VirtualWorkspace;
+class DidacticMenu;
+
+struct OscilloscopeTraceConfig {
+  String id;
+  String signalId;
+  String label;
+  bool enabled = true;
+};
+
+struct OscilloscopeCaptureRequest {
+  float startTime = 0.0f;
+  float sampleRate = 1000.0f;
+  size_t sampleCount = 512;
+};
+
+struct OscilloscopeTraceData {
+  String id;
+  String label;
+  bool enabled = true;
+  std::vector<float> samples;
+};
+
+struct OscilloscopeCaptureResult {
+  float sampleRate = 0.0f;
+  std::vector<OscilloscopeTraceData> traces;
+};
+
+class Oscilloscope {
+ public:
+  explicit Oscilloscope(VirtualWorkspace &workspace);
+
+  bool configureTrace(const OscilloscopeTraceConfig &config);
+  bool removeTrace(const String &id);
+  const std::vector<OscilloscopeTraceConfig> &traces() const { return traces_; }
+
+  bool capture(const OscilloscopeCaptureRequest &request,
+               OscilloscopeCaptureResult &result,
+               String &error) const;
+
+  void populateHelp(DidacticMenu &menu) const;
+
+ private:
+  VirtualWorkspace &workspace_;
+  std::vector<OscilloscopeTraceConfig> traces_;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/VirtualSignal.cpp
+++ b/src/virtual_lab/VirtualSignal.cpp
@@ -1,0 +1,118 @@
+#include "virtual_lab/VirtualSignal.h"
+
+#include <Arduino.h>
+#include <math.h>
+
+#include "virtual_lab/MathExpression.h"
+#include "virtual_lab/VirtualWorkspace.h"
+
+namespace virtual_lab {
+
+VirtualSignal::VirtualSignal(const String &id, const String &name, Kind kind)
+    : id_(id), name_(name), kind_(kind) {}
+
+ConstantSignal::ConstantSignal(const String &id, const String &name, float value)
+    : VirtualSignal(id, name, Kind::Constant), value_(value) {}
+
+float ConstantSignal::sample(const SampleContext &ctx) const {
+  (void)ctx;
+  return value_;
+}
+
+WaveformSignal::WaveformSignal(const String &id, const String &name)
+    : VirtualSignal(id, name, Kind::Waveform) {}
+
+void WaveformSignal::configure(const WaveformSettings &settings) {
+  settings_ = settings;
+}
+
+static float wrapPhase(float phase) {
+  while (phase < 0.0f) phase += 1.0f;
+  while (phase >= 1.0f) phase -= 1.0f;
+  return phase;
+}
+
+float WaveformSignal::sample(const SampleContext &ctx) const {
+  float t = ctx.time;
+  if (settings_.shape == WaveformShape::DC || settings_.frequency == 0.0f) {
+    return settings_.offset + settings_.amplitude;
+  }
+  float cycles = settings_.frequency * t + settings_.phase;
+  float phase = wrapPhase(cycles);
+  float value = 0.0f;
+  switch (settings_.shape) {
+    case WaveformShape::DC:
+      value = settings_.amplitude;
+      break;
+    case WaveformShape::Sine:
+      value = sinf(2.0f * PI * phase) * settings_.amplitude;
+      break;
+    case WaveformShape::Square: {
+      float duty = settings_.dutyCycle;
+      if (duty <= 0.0f) duty = 0.01f;
+      if (duty >= 1.0f) duty = 0.99f;
+      value = (phase < duty) ? settings_.amplitude : -settings_.amplitude;
+      break;
+    }
+    case WaveformShape::Triangle: {
+      if (phase < 0.25f) {
+        value = 4.0f * phase * settings_.amplitude;
+      } else if (phase < 0.75f) {
+        value = (2.0f - 4.0f * phase) * settings_.amplitude;
+      } else {
+        value = (-4.0f + 4.0f * phase) * settings_.amplitude;
+      }
+      break;
+    }
+    case WaveformShape::Sawtooth:
+      value = (2.0f * phase - 1.0f) * settings_.amplitude;
+      break;
+    case WaveformShape::Noise:
+      value = (random(-1000, 1001) / 1000.0f) * settings_.amplitude;
+      break;
+  }
+  return value + settings_.offset;
+}
+
+MathVirtualSignal::MathVirtualSignal(const String &id, const String &name)
+    : VirtualSignal(id, name, Kind::Math) {}
+
+bool MathVirtualSignal::configure(const String &expression,
+                                  const std::vector<VariableBinding> &bindings,
+                                  String &error) {
+  expression_ = expression;
+  bindings_ = bindings;
+  compiled_.reset(new MathExpression());
+  if (!compiled_->compile(expression, error)) {
+    compiled_.reset();
+    return false;
+  }
+  return true;
+}
+
+float MathVirtualSignal::sample(const SampleContext &ctx) const {
+  if (!compiled_) {
+    return NAN;
+  }
+  auto resolver = [&](const String &variable, float &out) -> bool {
+    for (const auto &binding : bindings_) {
+      if (binding.variable == variable) {
+        if (ctx.workspace == nullptr) {
+          return false;
+        }
+        return ctx.workspace->sampleSignal(binding.signalId, ctx.time, out);
+      }
+    }
+    if (ctx.workspace == nullptr) {
+      return false;
+    }
+    return ctx.workspace->sampleSignal(variable, ctx.time, out);
+  };
+  float value = NAN;
+  if (!compiled_->evaluate(resolver, value)) {
+    return NAN;
+  }
+  return value;
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/VirtualSignal.h
+++ b/src/virtual_lab/VirtualSignal.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <Arduino.h>
+#include <memory>
+#include <vector>
+
+namespace virtual_lab {
+
+class VirtualWorkspace;
+class MathExpression;
+
+class VirtualSignal {
+ public:
+  enum class Kind { Constant, Waveform, Math, External };
+
+  struct SampleContext {
+    const VirtualWorkspace *workspace;
+    float time;
+  };
+
+  VirtualSignal(const String &id, const String &name, Kind kind);
+  virtual ~VirtualSignal() = default;
+
+  const String &id() const { return id_; }
+  const String &name() const { return name_; }
+  void setName(const String &name) { name_ = name; }
+  Kind kind() const { return kind_; }
+
+  void setUnits(const String &units) { units_ = units; }
+  const String &units() const { return units_; }
+
+  void setHelpKey(const String &key) { helpKey_ = key; }
+  const String &helpKey() const { return helpKey_; }
+
+  virtual float sample(const SampleContext &ctx) const = 0;
+
+ protected:
+  String id_;
+  String name_;
+  String units_;
+  String helpKey_;
+  Kind kind_;
+};
+
+class ConstantSignal : public VirtualSignal {
+ public:
+  ConstantSignal(const String &id, const String &name, float value = 0.0f);
+  void setValue(float value) { value_ = value; }
+  float value() const { return value_; }
+  float sample(const SampleContext &ctx) const override;
+
+ private:
+  float value_;
+};
+
+enum class WaveformShape { DC, Sine, Square, Triangle, Sawtooth, Noise };
+
+struct WaveformSettings {
+  float amplitude = 1.0f;
+  float offset = 0.0f;
+  float frequency = 1.0f;
+  float phase = 0.0f;
+  float dutyCycle = 0.5f;
+  WaveformShape shape = WaveformShape::Sine;
+};
+
+class WaveformSignal : public VirtualSignal {
+ public:
+  WaveformSignal(const String &id, const String &name);
+  void configure(const WaveformSettings &settings);
+  const WaveformSettings &settings() const { return settings_; }
+  float sample(const SampleContext &ctx) const override;
+
+ private:
+  WaveformSettings settings_;
+};
+
+struct VariableBinding {
+  String variable;
+  String signalId;
+};
+
+class MathVirtualSignal : public VirtualSignal {
+ public:
+  MathVirtualSignal(const String &id, const String &name);
+
+  bool configure(const String &expression,
+                 const std::vector<VariableBinding> &bindings,
+                 String &error);
+
+  const String &expression() const { return expression_; }
+  const std::vector<VariableBinding> &bindings() const { return bindings_; }
+
+  float sample(const SampleContext &ctx) const override;
+
+ private:
+  std::unique_ptr<MathExpression> compiled_;
+  String expression_;
+  std::vector<VariableBinding> bindings_;
+};
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/VirtualWorkspace.cpp
+++ b/src/virtual_lab/VirtualWorkspace.cpp
@@ -1,0 +1,226 @@
+#include "virtual_lab/VirtualWorkspace.h"
+
+#include <ArduinoJson.h>
+#include <memory>
+
+#include "virtual_lab/FunctionGenerator.h"
+#include "virtual_lab/MathZone.h"
+#include "virtual_lab/Multimeter.h"
+#include "virtual_lab/Oscilloscope.h"
+
+namespace virtual_lab {
+
+VirtualWorkspace &VirtualWorkspace::Instance() {
+  static VirtualWorkspace instance;
+  return instance;
+}
+
+VirtualWorkspace::VirtualWorkspace() {
+  functionGenerator_.reset(new FunctionGenerator(*this));
+  oscilloscope_.reset(new Oscilloscope(*this));
+  multimeter_.reset(new Multimeter(*this));
+  mathZone_.reset(new MathZone(*this));
+  functionGenerator_->populateHelp(helpMenu_);
+  oscilloscope_->populateHelp(helpMenu_);
+  multimeter_->populateHelp(helpMenu_);
+  mathZone_->populateHelp(helpMenu_);
+}
+
+std::shared_ptr<VirtualSignal> VirtualWorkspace::findSignalInternal(
+    const String &id) {
+  for (auto &signal : signals_) {
+    if (signal->id() == id) {
+      return signal;
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<const VirtualSignal> VirtualWorkspace::findSignalInternal(
+    const String &id) const {
+  for (const auto &signal : signals_) {
+    if (signal->id() == id) {
+      return signal;
+    }
+  }
+  return nullptr;
+}
+
+bool VirtualWorkspace::registerSignal(
+    const std::shared_ptr<VirtualSignal> &signal) {
+  if (!signal) return false;
+  for (auto &existing : signals_) {
+    if (existing->id() == signal->id()) {
+      existing = signal;
+      return true;
+    }
+  }
+  signals_.push_back(signal);
+  return true;
+}
+
+bool VirtualWorkspace::removeSignal(const String &id) {
+  for (size_t i = 0; i < signals_.size(); ++i) {
+    if (signals_[i]->id() == id) {
+      signals_.erase(signals_.begin() + i);
+      return true;
+    }
+  }
+  return false;
+}
+
+std::shared_ptr<VirtualSignal> VirtualWorkspace::findSignal(
+    const String &id) {
+  return findSignalInternal(id);
+}
+
+std::shared_ptr<const VirtualSignal> VirtualWorkspace::findSignal(
+    const String &id) const {
+  return findSignalInternal(id);
+}
+
+bool VirtualWorkspace::sampleSignal(const String &id, float time,
+                                    float &out) const {
+  auto signal = findSignalInternal(id);
+  if (!signal) {
+    return false;
+  }
+  VirtualSignal::SampleContext ctx;
+  ctx.workspace = this;
+  ctx.time = time;
+  out = signal->sample(ctx);
+  return !isnan(out);
+}
+
+bool VirtualWorkspace::sampleSignalSeries(const String &id, float startTime,
+                                          float interval, size_t count,
+                                          std::vector<float> &out) const {
+  out.clear();
+  out.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    float sampleTime = startTime + interval * static_cast<float>(i);
+    float value = NAN;
+    if (!sampleSignal(id, sampleTime, value)) {
+      return false;
+    }
+    out.push_back(value);
+  }
+  return true;
+}
+
+FunctionGenerator &VirtualWorkspace::functionGenerator() {
+  return *functionGenerator_;
+}
+
+Oscilloscope &VirtualWorkspace::oscilloscope() { return *oscilloscope_; }
+
+Multimeter &VirtualWorkspace::multimeter() { return *multimeter_; }
+
+MathZone &VirtualWorkspace::mathZone() { return *mathZone_; }
+
+const FunctionGenerator &VirtualWorkspace::functionGenerator() const {
+  return *functionGenerator_;
+}
+
+const Oscilloscope &VirtualWorkspace::oscilloscope() const {
+  return *oscilloscope_;
+}
+
+const Multimeter &VirtualWorkspace::multimeter() const {
+  return *multimeter_;
+}
+
+const MathZone &VirtualWorkspace::mathZone() const { return *mathZone_; }
+
+void VirtualWorkspace::populateSummaryJson(JsonDocument &doc) const {
+  JsonArray signals = doc.createNestedArray("signals");
+  for (const auto &signal : signals_) {
+    JsonObject obj = signals.createNestedObject();
+    obj["id"] = signal->id();
+    obj["name"] = signal->name();
+    obj["units"] = signal->units();
+    switch (signal->kind()) {
+      case VirtualSignal::Kind::Constant:
+        obj["type"] = "constant";
+        break;
+      case VirtualSignal::Kind::Waveform:
+        obj["type"] = "waveform";
+        break;
+      case VirtualSignal::Kind::Math:
+        obj["type"] = "math";
+        break;
+      case VirtualSignal::Kind::External:
+        obj["type"] = "external";
+        break;
+    }
+  }
+  JsonObject instruments = doc.createNestedObject("instruments");
+  JsonArray fgOutputs = instruments.createNestedArray("functionGenerator");
+  for (const auto &output : functionGenerator_->outputs()) {
+    JsonObject obj = fgOutputs.createNestedObject();
+    obj["id"] = output.id;
+    obj["name"] = output.name;
+    obj["enabled"] = output.enabled;
+    obj["units"] = output.units;
+    obj["amplitude"] = output.settings.amplitude;
+    obj["offset"] = output.settings.offset;
+    obj["frequency"] = output.settings.frequency;
+    obj["phase"] = output.settings.phase;
+    obj["dutyCycle"] = output.settings.dutyCycle;
+    switch (output.settings.shape) {
+      case WaveformShape::DC:
+        obj["shape"] = "dc";
+        break;
+      case WaveformShape::Sine:
+        obj["shape"] = "sine";
+        break;
+      case WaveformShape::Square:
+        obj["shape"] = "square";
+        break;
+      case WaveformShape::Triangle:
+        obj["shape"] = "triangle";
+        break;
+      case WaveformShape::Sawtooth:
+        obj["shape"] = "saw";
+        break;
+      case WaveformShape::Noise:
+        obj["shape"] = "noise";
+        break;
+    }
+  }
+  JsonArray scopeTraces = instruments.createNestedArray("oscilloscope");
+  for (const auto &trace : oscilloscope_->traces()) {
+    JsonObject obj = scopeTraces.createNestedObject();
+    obj["id"] = trace.id;
+    obj["signalId"] = trace.signalId;
+    obj["label"] = trace.label;
+    obj["enabled"] = trace.enabled;
+  }
+  JsonArray meterInputs = instruments.createNestedArray("multimeter");
+  for (const auto &input : multimeter_->inputs()) {
+    JsonObject obj = meterInputs.createNestedObject();
+    obj["id"] = input.id;
+    obj["signalId"] = input.signalId;
+    obj["label"] = input.label;
+    obj["enabled"] = input.enabled;
+  }
+  JsonArray mathExpressions = instruments.createNestedArray("mathZone");
+  for (const auto &exprId : mathZone_->expressions()) {
+    JsonObject obj = mathExpressions.createNestedObject();
+    obj["id"] = exprId;
+    auto signal = findSignal(exprId);
+    auto mathSignal = std::dynamic_pointer_cast<MathVirtualSignal>(signal);
+    if (mathSignal) {
+      obj["expression"] = mathSignal->expression();
+    }
+  }
+  JsonArray help = doc.createNestedArray("help");
+  for (const auto &entry : helpMenu_.entries()) {
+    JsonObject obj = help.createNestedObject();
+    obj["key"] = entry.key;
+    obj["title"] = entry.title;
+    obj["text"] = entry.text;
+  }
+}
+
+}  // namespace virtual_lab

--- a/src/virtual_lab/VirtualWorkspace.h
+++ b/src/virtual_lab/VirtualWorkspace.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Arduino.h>
+#include <memory>
+#include <vector>
+
+#include "virtual_lab/DidacticMenu.h"
+#include "virtual_lab/VirtualSignal.h"
+
+class JsonDocument;
+
+namespace virtual_lab {
+
+class FunctionGenerator;
+class Oscilloscope;
+class Multimeter;
+class MathZone;
+
+class VirtualWorkspace {
+ public:
+  static VirtualWorkspace &Instance();
+
+  VirtualWorkspace();
+
+  bool registerSignal(const std::shared_ptr<VirtualSignal> &signal);
+  bool removeSignal(const String &id);
+  std::shared_ptr<VirtualSignal> findSignal(const String &id);
+  std::shared_ptr<const VirtualSignal> findSignal(const String &id) const;
+
+  bool sampleSignal(const String &id, float time, float &out) const;
+  bool sampleSignalSeries(const String &id, float startTime, float interval,
+                          size_t count, std::vector<float> &out) const;
+
+  FunctionGenerator &functionGenerator();
+  Oscilloscope &oscilloscope();
+  Multimeter &multimeter();
+  MathZone &mathZone();
+
+  const FunctionGenerator &functionGenerator() const;
+  const Oscilloscope &oscilloscope() const;
+  const Multimeter &multimeter() const;
+  const MathZone &mathZone() const;
+
+  DidacticMenu &helpMenu() { return helpMenu_; }
+  const DidacticMenu &helpMenu() const { return helpMenu_; }
+
+  void populateSummaryJson(JsonDocument &doc) const;
+
+ private:
+  std::shared_ptr<VirtualSignal> findSignalInternal(const String &id);
+  std::shared_ptr<const VirtualSignal> findSignalInternal(const String &id) const;
+
+  std::vector<std::shared_ptr<VirtualSignal>> signals_;
+  std::unique_ptr<FunctionGenerator> functionGenerator_;
+  std::unique_ptr<Oscilloscope> oscilloscope_;
+  std::unique_ptr<Multimeter> multimeter_;
+  std::unique_ptr<MathZone> mathZone_;
+  DidacticMenu helpMenu_;
+};
+
+}  // namespace virtual_lab


### PR DESCRIPTION
## Summary
- add a modular virtual lab subsystem with signals, math zone, oscilloscope, multimeter, function generator and didactic help content
- expose HTTP API endpoints for configuring and querying virtual instruments, math expressions, captures and measurements
- register reference signals at boot to illustrate how the virtual workspace can feed instruments and equations

## Testing
- platformio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf764520c832eb933ce70a5ae2247