### PR TITLE
Fix build issues for math expressions and virtual workspace

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,10 @@
 #include <vector>
 
 #include "build_version.h"
+#include "virtual_lab/FunctionGenerator.h"
+#include "virtual_lab/MathZone.h"
+#include "virtual_lab/Multimeter.h"
+#include "virtual_lab/Oscilloscope.h"
 #include "virtual_lab/VirtualWorkspace.h"
 
 static void logPrintf(const char *fmt, ...);

--- a/src/virtual_lab/MathExpression.cpp
+++ b/src/virtual_lab/MathExpression.cpp
@@ -11,23 +11,13 @@
 
 namespace virtual_lab {
 
-namespace {
-
-struct Node {
-  enum class Type { Constant, Variable, Unary, Binary, Function };
-  Type type;
-  float constant = 0.0f;
-  char op = '\0';
-  String identifier;
-  std::vector<std::unique_ptr<Node>> children;
-};
-
-class Parser {
+class MathExpressionParser {
  public:
-  Parser(const std::string &source, MathExpression *owner, String &error)
+  MathExpressionParser(const std::string &source, MathExpression *owner,
+                       String &error)
       : source_(source), owner_(owner), error_(error) {}
 
-  std::unique_ptr<Node> parse() {
+  std::unique_ptr<MathExpression::Node> parse() {
     skipWhitespace();
     auto expr = parseExpression();
     skipWhitespace();
@@ -42,6 +32,8 @@ class Parser {
   }
 
  private:
+  using Node = MathExpression::Node;
+
   std::unique_ptr<Node> parseExpression() {
     auto node = parseTerm();
     if (!node) return nullptr;
@@ -261,6 +253,8 @@ class Parser {
   size_t position_ = 0;
 };
 
+namespace {
+
 float applyBinary(char op, float lhs, float rhs) {
   switch (op) {
     case '+':
@@ -425,7 +419,7 @@ bool MathExpression::compile(const String &expression, String &errorMessage) {
   asciiExpression_ = std::string(expression.c_str());
   variables_.clear();
   errorMessage = "";
-  Parser parser(asciiExpression_, this, errorMessage);
+  MathExpressionParser parser(asciiExpression_, this, errorMessage);
   root_ = parser.parse();
   if (!root_) {
     return false;

--- a/src/virtual_lab/MathExpression.h
+++ b/src/virtual_lab/MathExpression.h
@@ -8,6 +8,8 @@
 
 namespace virtual_lab {
 
+class MathExpressionParser;
+
 class MathExpression {
  public:
   MathExpression();
@@ -22,7 +24,16 @@ class MathExpression {
   const String &expression() const { return expression_; }
 
  private:
-  struct Node;
+  friend class MathExpressionParser;
+
+  struct Node {
+    enum class Type { Constant, Variable, Unary, Binary, Function };
+    Type type;
+    float constant = 0.0f;
+    char op = '\0';
+    String identifier;
+    std::vector<std::unique_ptr<Node>> children;
+  };
 
   std::unique_ptr<Node> parseExpression(String &errorMessage);
 

--- a/src/virtual_lab/VirtualWorkspace.h
+++ b/src/virtual_lab/VirtualWorkspace.h
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <Arduino.h>
+#include <ArduinoJson.h>
 #include <memory>
 #include <vector>
 
 #include "virtual_lab/DidacticMenu.h"
 #include "virtual_lab/VirtualSignal.h"
-
-class JsonDocument;
 
 namespace virtual_lab {
 


### PR DESCRIPTION
## Summary
- define MathExpression::Node within the class and introduce a MathExpressionParser helper to build expression trees
- expose registerVariable access to the parser and include ArduinoJson so JsonDocument resolves correctly
- include the concrete instrument headers in main to use their configuration structures

## Testing
- Not run (PlatformIO CLI `pio` unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbfd21bc0c832ea7b8661caaf0dff8