### PR TITLE
Fix MathVirtualSignal destructor dependency

### DIFF
--- a/src/virtual_lab/VirtualSignal.cpp
+++ b/src/virtual_lab/VirtualSignal.cpp
@@ -77,6 +77,8 @@ float WaveformSignal::sample(const SampleContext &ctx) const {
 MathVirtualSignal::MathVirtualSignal(const String &id, const String &name)
     : VirtualSignal(id, name, Kind::Math) {}
 
+MathVirtualSignal::~MathVirtualSignal() = default;
+
 bool MathVirtualSignal::configure(const String &expression,
                                   const std::vector<VariableBinding> &bindings,
                                   String &error) {

--- a/src/virtual_lab/VirtualSignal.h
+++ b/src/virtual_lab/VirtualSignal.h
@@ -83,6 +83,7 @@ struct VariableBinding {
 class MathVirtualSignal : public VirtualSignal {
  public:
   MathVirtualSignal(const String &id, const String &name);
+  ~MathVirtualSignal();
 
   bool configure(const String &expression,
                  const std::vector<VariableBinding> &bindings,


### PR DESCRIPTION
## Summary
- declare MathVirtualSignal destructor in the header and define it in the implementation file so the MathExpression type is complete when destroyed

## Testing
- pio run *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc02def0fc832e87d80f81300c6a00