### PR TITLE
Fix const cast in math signal lookup

### DIFF
--- a/src/virtual_lab/VirtualWorkspace.cpp
+++ b/src/virtual_lab/VirtualWorkspace.cpp
@@ -209,7 +209,8 @@ void VirtualWorkspace::populateSummaryJson(JsonDocument &doc) const {
     JsonObject obj = mathExpressions.createNestedObject();
     obj["id"] = exprId;
     auto signal = findSignal(exprId);
-    auto mathSignal = std::dynamic_pointer_cast<MathVirtualSignal>(signal);
+    auto mathSignal =
+        std::dynamic_pointer_cast<const MathVirtualSignal>(signal);
     if (mathSignal) {
       obj["expression"] = mathSignal->expression();
     }


### PR DESCRIPTION
## Summary
- adjust math expression summary lookup to cast to a const MathVirtualSignal

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc05825348832ebfa79239c2732caa