### PR TITLE
Avoid RTTI usage for math signal lookup

### DIFF
--- a/src/virtual_lab/VirtualSignal.h
+++ b/src/virtual_lab/VirtualSignal.h
@@ -9,6 +9,8 @@ namespace virtual_lab {
 class VirtualWorkspace;
 class MathExpression;
 
+class MathVirtualSignal;
+
 class VirtualSignal {
  public:
   enum class Kind { Constant, Waveform, Math, External };
@@ -33,6 +35,8 @@ class VirtualSignal {
   const String &helpKey() const { return helpKey_; }
 
   virtual float sample(const SampleContext &ctx) const = 0;
+
+  virtual const MathVirtualSignal *asMathSignal() const { return nullptr; }
 
  protected:
   String id_;
@@ -84,6 +88,8 @@ class MathVirtualSignal : public VirtualSignal {
  public:
   MathVirtualSignal(const String &id, const String &name);
   ~MathVirtualSignal();
+
+  const MathVirtualSignal *asMathSignal() const override { return this; }
 
   bool configure(const String &expression,
                  const std::vector<VariableBinding> &bindings,

--- a/src/virtual_lab/VirtualWorkspace.cpp
+++ b/src/virtual_lab/VirtualWorkspace.cpp
@@ -209,8 +209,10 @@ void VirtualWorkspace::populateSummaryJson(JsonDocument &doc) const {
     JsonObject obj = mathExpressions.createNestedObject();
     obj["id"] = exprId;
     auto signal = findSignal(exprId);
-    auto mathSignal =
-        std::dynamic_pointer_cast<const MathVirtualSignal>(signal);
+    if (!signal) {
+      continue;
+    }
+    auto mathSignal = signal->asMathSignal();
     if (mathSignal) {
       obj["expression"] = mathSignal->expression();
     }


### PR DESCRIPTION
## Summary
- add a virtual helper on VirtualSignal to expose MathVirtualSignal instances without relying on RTTI
- update the workspace JSON summary generation to use the helper when fetching math expressions

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc06f63a54832ebceb62437d1d6be5