### PR TITLE
Add virtual lab web experience

### DIFF
--- a/data/assets/virtual-lab-logo.svg
+++ b/data/assets/virtual-lab-logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 140">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a6dd8"/>
+      <stop offset="100%" stop-color="#45d1ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="130" height="130" rx="18" fill="url(#grad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M38 88h20l12-52 20 92 12-40h18"/>
+    <circle cx="42" cy="46" r="12"/>
+    <path d="M26 108h88"/>
+    <path d="M48 108v16m44-16v16"/>
+    <path d="M58 34h24"/>
+  </g>
+</svg>

--- a/data/index.html
+++ b/data/index.html
@@ -15,12 +15,57 @@
     .status-message { font-size: 0.9em; color: #555; min-height: 1.2em; }
     .status-message.error { color: #c0392b; }
     #privateFilesTable .empty-row td { text-align: center; color: #666; font-style: italic; }
+    .virtual-lab-entry {
+      margin: 1.5em 0 2.5em;
+      display: flex;
+      align-items: center;
+      gap: 1.5em;
+      padding: 1em 1.5em;
+      border: 1px solid #d0e6ff;
+      border-radius: 16px;
+      background: linear-gradient(120deg, rgba(10, 109, 216, 0.05), rgba(69, 209, 255, 0.05));
+      box-shadow: 0 8px 20px rgba(10, 109, 216, 0.08);
+    }
+    .virtual-lab-entry img {
+      width: 96px;
+      height: auto;
+      display: block;
+    }
+    .virtual-lab-entry .virtual-lab-title {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6em;
+      font-size: 1.2em;
+      font-weight: 700;
+      color: #0a6dd8;
+    }
+    .virtual-lab-entry .virtual-lab-title:hover {
+      color: #06488f;
+    }
+    .virtual-lab-entry p {
+      margin: 0.3em 0 0;
+      color: #344055;
+      max-width: 460px;
+      line-height: 1.4;
+    }
   </style>
   <script src="auth.js"></script>
 </head>
 <body>
 <h1>MiniLabBox Node</h1>
 <p>Identifiant du nœud : <strong><span id="nodeId"></span></strong></p>
+
+<div class="virtual-lab-entry">
+  <a href="virtual-lab/index.html" aria-label="Accéder au Virtual Lab">
+    <img src="assets/virtual-lab-logo.svg" alt="Logo Virtual Lab">
+  </a>
+  <div>
+    <a class="virtual-lab-title" href="virtual-lab/index.html">
+      Accéder au Virtual Lab professionnel
+    </a>
+    <p>Un environnement immersif regroupant oscilloscope Tektronix, multimètre de laboratoire et générateur de fonctions.</p>
+  </div>
+</div>
 
 <h2>Entrées</h2>
 <table id="inputsTable">
@@ -43,7 +88,8 @@
   <a href="private/power-monitor.html">Mesure de puissance</a> |
   <a href="private/io-exemples.html">Bibliothèque d'exemples IO</a> |
   <a href="logs.html">Logs système</a> |
-  <a href="editor.html">Éditeur de fichiers</a>
+  <a href="editor.html">Éditeur de fichiers</a> |
+  <a href="virtual-lab/index.html">Virtual Lab</a>
 </p>
 
 <h2>Fichiers HTML privés</h2>

--- a/data/virtual-lab/css/style.css
+++ b/data/virtual-lab/css/style.css
@@ -1,0 +1,303 @@
+:root {
+  --primary: #0a6dd8;
+  --primary-dark: #06488f;
+  --accent: #45d1ff;
+  --background: #0f172a;
+  --surface: rgba(15, 23, 42, 0.88);
+  --surface-light: rgba(255, 255, 255, 0.04);
+  --text: #f8fafc;
+  --text-muted: #94a3b8;
+  --divider: rgba(148, 163, 184, 0.3);
+  font-family: 'Segoe UI', Roboto, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(69, 209, 255, 0.16), transparent 60%),
+              linear-gradient(135deg, #050816 0%, #0f172a 55%, #020617 100%);
+  color: var(--text);
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem 4rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 3rem;
+}
+
+header a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: color 0.2s ease;
+}
+
+header a:hover {
+  color: var(--accent);
+}
+
+.hero {
+  background: var(--surface);
+  border: 1px solid var(--divider);
+  border-radius: 24px;
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.55);
+}
+
+.hero-visual {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.hero-visual img {
+  width: min(220px, 100%);
+  height: auto;
+  filter: drop-shadow(0 18px 28px rgba(4, 12, 40, 0.45));
+}
+
+.hero-content h1 {
+  font-size: clamp(2rem, 4vw, 2.9rem);
+  margin: 0 0 1rem;
+}
+
+.hero-content p {
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.hero-content .cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #0b1120;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-content .cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 28px rgba(69, 209, 255, 0.25);
+}
+
+.section-title {
+  margin: 3rem 0 1rem;
+  font-size: 1.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.instrument-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.instrument-card {
+  background: var(--surface);
+  border: 1px solid var(--divider);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.instrument-card h3 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.instrument-card p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.instrument-display {
+  background: var(--surface-light);
+  border: 1px solid var(--divider);
+  border-radius: 16px;
+  padding: 1rem;
+  min-height: 160px;
+  position: relative;
+  overflow: hidden;
+}
+
+.instrument-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.instrument-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  gap: 0.4rem;
+}
+
+.instrument-controls select,
+.instrument-controls input {
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  min-width: 120px;
+  font-size: 0.9rem;
+}
+
+.instrument-controls progress {
+  width: 180px;
+  height: 12px;
+  -webkit-appearance: none;
+  appearance: none;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--divider);
+}
+
+.instrument-controls progress::-webkit-progress-bar {
+  background: transparent;
+}
+
+.instrument-controls progress::-webkit-progress-value {
+  background: linear-gradient(135deg, var(--accent), var(--primary));
+}
+
+.instrument-controls progress::-moz-progress-bar {
+  background: linear-gradient(135deg, var(--accent), var(--primary));
+}
+
+.math-zone {
+  background: linear-gradient(145deg, rgba(10, 109, 216, 0.22), rgba(69, 209, 255, 0.08));
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid rgba(69, 209, 255, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.math-zone h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.math-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.math-input input {
+  flex: 1;
+  min-width: 220px;
+  border-radius: 999px;
+  border: 1px solid rgba(69, 209, 255, 0.32);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+}
+
+.math-input button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: linear-gradient(135deg, var(--accent), var(--primary));
+  color: #0b1120;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.math-input button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 25px rgba(69, 209, 255, 0.22);
+}
+
+.math-result {
+  font-size: 1.1rem;
+  color: var(--accent);
+  min-height: 1.4em;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(69, 209, 255, 0.08);
+  border: 1px solid rgba(69, 209, 255, 0.32);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+}
+
+canvas.oscilloscope-display {
+  width: 100%;
+  height: 100%;
+}
+
+.measurement-value {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.measurement-unit {
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 2.5rem 1.1rem 3rem;
+  }
+
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .hero {
+    padding: 1.5rem;
+  }
+}

--- a/data/virtual-lab/index.html
+++ b/data/virtual-lab/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>MiniLabBox | Virtual Lab</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a href="../index.html" class="return-link" aria-label="Retour à l'accueil">
+        &#x2190; Retour au tableau de bord
+      </a>
+      <span class="status-badge">Environnement virtuel</span>
+    </header>
+
+    <section class="hero">
+      <div class="hero-visual">
+        <img src="../assets/virtual-lab-logo.svg" alt="Logo Virtual Lab MiniLabBox">
+      </div>
+      <div class="hero-content">
+        <h1>Virtual Lab Professionnel</h1>
+        <p>
+          Retrouvez vos instruments de mesure dans une interface immersive inspirée des laboratoires modernes.
+          Configurez l'oscilloscope, le multimètre et le générateur de fonctions comme si vous étiez devant le matériel.
+        </p>
+        <a class="cta" href="#lab">Explorer le laboratoire</a>
+      </div>
+    </section>
+
+    <h2 class="section-title" id="lab">Instruments</h2>
+    <section class="instrument-grid">
+      <article class="instrument-card" id="oscilloscope"></article>
+      <article class="instrument-card" id="multimeter"></article>
+      <article class="instrument-card" id="function-generator"></article>
+    </section>
+
+    <h2 class="section-title">Zone mathématique</h2>
+    <section class="math-zone" id="math-zone"></section>
+  </div>
+
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/data/virtual-lab/js/functionGenerator.js
+++ b/data/virtual-lab/js/functionGenerator.js
@@ -1,0 +1,138 @@
+const WAVE_TYPES = {
+  sine: { label: 'Sinus', description: 'Signal pur pour les mesures de référence.' },
+  square: { label: 'Carré', description: 'Temps de montée rapide pour tests logiques.' },
+  ramp: { label: 'Rampe', description: 'Variation linéaire pour stimulation progressive.' },
+  pulse: { label: 'Impulsion', description: 'Impulsions fines pour tests de réponse.' }
+};
+
+function drawPreview(canvas, type) {
+  const ctx = canvas.getContext('2d');
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+  ctx.strokeStyle = 'rgba(148, 163, 184, 0.35)';
+  ctx.lineWidth = 1;
+  for (let i = 1; i < 6; i += 1) {
+    const y = (height / 6) * i;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = '#45d1ff';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  const cycles = 2;
+  const samples = 500;
+  for (let i = 0; i <= samples; i += 1) {
+    const ratio = i / samples;
+    const x = ratio * width;
+    let yRatio = 0;
+    const phase = ratio * cycles * Math.PI * 2;
+    switch (type) {
+      case 'square':
+        yRatio = Math.sin(phase) >= 0 ? 0.15 : 0.85;
+        break;
+      case 'ramp':
+        yRatio = 0.15 + (ratio * cycles % 1) * 0.7;
+        break;
+      case 'pulse':
+        yRatio = (phase % (Math.PI * 2)) < 0.3 ? 0.15 : 0.85;
+        break;
+      case 'sine':
+      default:
+        yRatio = 0.5 - Math.sin(phase) * 0.35;
+        break;
+    }
+    const y = yRatio * height;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.stroke();
+}
+
+function formatFrequency(value) {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)} MHz`;
+  }
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1)} kHz`;
+  }
+  return `${value.toFixed(0)} Hz`;
+}
+
+export function mountFunctionGenerator(container) {
+  if (!container) return;
+  container.innerHTML = `
+    <span class="status-badge">Générateur RF/Arb</span>
+    <h3>Générateur de fonctions 2 canaux</h3>
+    <p>
+      Sélectionnez vos formes d'onde et paramètres de sortie pour alimenter bancs d'essai et prototypes.
+    </p>
+    <div class="instrument-display">
+      <canvas width="520" height="160" aria-label="Aperçu signal" id="function-preview"></canvas>
+      <div id="function-summary" class="measurement-unit"></div>
+    </div>
+    <div class="instrument-controls">
+      <label>
+        Forme d'onde
+        <select id="function-wave"></select>
+      </label>
+      <label>
+        Fréquence
+        <input type="range" id="function-frequency" min="10" max="1000000" step="10" value="1000">
+      </label>
+      <label>
+        Amplitude (Vpp)
+        <input type="range" id="function-amplitude" min="0.2" max="10" step="0.2" value="2">
+      </label>
+      <label>
+        Offset (V)
+        <input type="range" id="function-offset" min="-5" max="5" step="0.1" value="0">
+      </label>
+      <label>
+        Sortie
+        <select id="function-output">
+          <option value="on">Activée</option>
+          <option value="off">Désactivée</option>
+        </select>
+      </label>
+    </div>
+  `;
+
+  const preview = container.querySelector('#function-preview');
+  const summary = container.querySelector('#function-summary');
+  const waveSelect = container.querySelector('#function-wave');
+  const frequency = container.querySelector('#function-frequency');
+  const amplitude = container.querySelector('#function-amplitude');
+  const offset = container.querySelector('#function-offset');
+  const output = container.querySelector('#function-output');
+
+  Object.entries(WAVE_TYPES).forEach(([value, { label }]) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    waveSelect.appendChild(option);
+  });
+
+  const update = () => {
+    const currentWave = waveSelect.value;
+    drawPreview(preview, currentWave);
+    const amplitudeValue = parseFloat(amplitude.value).toFixed(1);
+    const offsetValue = parseFloat(offset.value).toFixed(1);
+    const freqText = formatFrequency(parseFloat(frequency.value));
+    const waveInfo = WAVE_TYPES[currentWave];
+    summary.textContent = `${waveInfo.label} • ${freqText} • ${amplitudeValue} Vpp • Offset ${offsetValue} V • Sortie ${output.value === 'on' ? 'ON' : 'OFF'}`;
+  };
+
+  [waveSelect, frequency, amplitude, offset, output].forEach((input) => {
+    input.addEventListener('input', update);
+    input.addEventListener('change', update);
+  });
+
+  waveSelect.value = 'sine';
+  update();
+}

--- a/data/virtual-lab/js/main.js
+++ b/data/virtual-lab/js/main.js
@@ -1,0 +1,11 @@
+import { mountOscilloscope } from './oscilloscope.js';
+import { mountMultimeter } from './multimeter.js';
+import { mountFunctionGenerator } from './functionGenerator.js';
+import { mountMathZone } from './mathZone.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  mountOscilloscope(document.getElementById('oscilloscope'));
+  mountMultimeter(document.getElementById('multimeter'));
+  mountFunctionGenerator(document.getElementById('function-generator'));
+  mountMathZone(document.getElementById('math-zone'));
+});

--- a/data/virtual-lab/js/mathZone.js
+++ b/data/virtual-lab/js/mathZone.js
@@ -1,0 +1,69 @@
+const EXAMPLES = [
+  'FFT(200 MSa/s, 1024 points)',
+  "Puissance moyenne d'une sinusoïde",
+  'Conversion Vpp -> Vrms'
+];
+
+function renderExamples(list) {
+  return list.map((item) => `<li>${item}</li>`).join('');
+}
+
+function safeEval(expression) {
+  // Autorise seulement des caractères mathématiques de base
+  const sanitized = expression.replace(/[^0-9+\-*/().,^%\sA-Za-z]/g, '');
+  if (!sanitized.trim()) {
+    throw new Error('Expression vide');
+  }
+  // eslint-disable-next-line no-new-func
+  const evaluator = Function('Math', `"use strict"; return (${sanitized});`);
+  return evaluator(Math);
+}
+
+export function mountMathZone(container) {
+  if (!container) return;
+  container.innerHTML = `
+    <div>
+      <h3>Calculs rapides</h3>
+      <p>
+        Évaluez instantanément vos formules : rapports de division, conversions d'unités ou calculs de puissance.
+        La zone est isolée pour simplifier la maintenance du code.
+      </p>
+    </div>
+    <div class="math-input">
+      <input type="text" id="math-expression" placeholder="Exemple : (5.0/2) * Math.PI" aria-label="Expression mathématique">
+      <button type="button" id="math-run">Calculer</button>
+    </div>
+    <div class="math-result" id="math-result" aria-live="polite"></div>
+    <div>
+      <h4>Idées de calculs</h4>
+      <ul>${renderExamples(EXAMPLES)}</ul>
+    </div>
+  `;
+
+  const input = container.querySelector('#math-expression');
+  const result = container.querySelector('#math-result');
+  const runButton = container.querySelector('#math-run');
+
+  const evaluate = () => {
+    const expression = input.value;
+    if (!expression.trim()) {
+      result.textContent = 'Saisissez une expression à évaluer.';
+      return;
+    }
+    try {
+      const value = safeEval(expression);
+      result.textContent = Number.isFinite(value)
+        ? `Résultat : ${value}`
+        : 'Expression non numérique.';
+    } catch (error) {
+      result.textContent = `Erreur : ${error.message}`;
+    }
+  };
+
+  runButton.addEventListener('click', evaluate);
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      evaluate();
+    }
+  });
+}

--- a/data/virtual-lab/js/multimeter.js
+++ b/data/virtual-lab/js/multimeter.js
@@ -1,0 +1,89 @@
+const MEASUREMENTS = {
+  voltage: { label: 'Tension DC', unit: 'V', range: [3.28, 3.34] },
+  voltageAc: { label: 'Tension AC', unit: 'V RMS', range: [229.2, 231.5] },
+  current: { label: 'Courant', unit: 'mA', range: [12.3, 12.9] },
+  resistance: { label: 'Résistance', unit: 'kΩ', range: [1.48, 1.53] }
+};
+
+function randomInRange([min, max]) {
+  return Math.random() * (max - min) + min;
+}
+
+function formatValue(value) {
+  return value.toFixed(3).replace('.', ',');
+}
+
+export function mountMultimeter(container) {
+  if (!container) return;
+  container.innerHTML = `
+    <span class="status-badge">DMM de laboratoire</span>
+    <h3>Multimètre 6½ digits</h3>
+    <p>
+      Mesurez avec stabilité et précision. La simulation reproduit une lecture typique d'un multimètre
+      de paillasse haut de gamme avec filtrage numérique.
+    </p>
+    <div class="instrument-display" role="img" aria-label="Affichage de mesure">
+      <div class="measurement-value" id="multimeter-value">0,000</div>
+      <div class="measurement-unit" id="multimeter-unit">V</div>
+    </div>
+    <div class="instrument-controls">
+      <label>
+        Mode
+        <select id="multimeter-mode"></select>
+      </label>
+      <label>
+        Filtre numérique
+        <input type="range" id="multimeter-filter" min="0" max="100" value="40">
+      </label>
+      <label>
+        Barregraph
+        <progress id="multimeter-bar" max="100" value="30" aria-label="Barregraph numérique"></progress>
+      </label>
+    </div>
+  `;
+
+  const modeSelect = container.querySelector('#multimeter-mode');
+  const valueDisplay = container.querySelector('#multimeter-value');
+  const unitDisplay = container.querySelector('#multimeter-unit');
+  const filterRange = container.querySelector('#multimeter-filter');
+  const bar = container.querySelector('#multimeter-bar');
+
+  Object.entries(MEASUREMENTS).forEach(([key, { label }]) => {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = label;
+    modeSelect.appendChild(option);
+  });
+
+  let previousValue = null;
+  const getSmoothedValue = (raw, smoothing) => {
+    if (previousValue === null) {
+      previousValue = raw;
+      return raw;
+    }
+    const alpha = Math.max(0.02, 1 - smoothing);
+    previousValue = previousValue + (raw - previousValue) * alpha;
+    return previousValue;
+  };
+
+  const updateDisplay = () => {
+    const { range, unit } = MEASUREMENTS[modeSelect.value] || MEASUREMENTS.voltage;
+    const rawValue = randomInRange(range);
+    const smoothing = parseInt(filterRange.value, 10) / 100;
+    const value = getSmoothedValue(rawValue, smoothing);
+    valueDisplay.textContent = formatValue(value);
+    unitDisplay.textContent = unit;
+    bar.value = Math.min(100, Math.max(0, ((value - range[0]) / (range[1] - range[0])) * 100));
+  };
+
+  modeSelect.addEventListener('change', () => {
+    previousValue = null;
+    updateDisplay();
+  });
+
+  filterRange.addEventListener('input', updateDisplay);
+
+  modeSelect.value = 'voltage';
+  updateDisplay();
+  setInterval(updateDisplay, 1100);
+}

--- a/data/virtual-lab/js/oscilloscope.js
+++ b/data/virtual-lab/js/oscilloscope.js
@@ -1,0 +1,144 @@
+const WAVEFORMS = {
+  sinus: {
+    label: 'Sinusoïdale',
+    generator: (x) => Math.sin(x)
+  },
+  carree: {
+    label: 'Carrée',
+    generator: (x) => (Math.sin(x) >= 0 ? 1 : -1)
+  },
+  dentDeScie: {
+    label: 'Dent de scie',
+    generator: (x) => ((x / Math.PI) % 2) - 1
+  }
+};
+
+function formatTimebase(value) {
+  if (value < 1) {
+    return `${(value * 1000).toFixed(0)} µs/div`;
+  }
+  return `${value.toFixed(1)} ms/div`;
+}
+
+function drawWaveform(canvas, options) {
+  const ctx = canvas.getContext('2d');
+  const { waveform, amplitude, offset } = options;
+  const { width, height } = canvas;
+
+  ctx.clearRect(0, 0, width, height);
+
+  ctx.strokeStyle = 'rgba(148, 163, 184, 0.3)';
+  ctx.lineWidth = 1;
+  const divisions = 8;
+  for (let i = 1; i < divisions; i += 1) {
+    const x = (width / divisions) * i;
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, height);
+    ctx.stroke();
+    const y = (height / divisions) * i;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = '#45d1ff';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  const samples = 600;
+  for (let i = 0; i <= samples; i += 1) {
+    const ratio = i / samples;
+    const x = ratio * width;
+    const angle = ratio * Math.PI * 8;
+    const value = waveform(angle);
+    const y = height / 2 - (value * amplitude + offset) * (height / 3);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.stroke();
+}
+
+export function mountOscilloscope(container) {
+  if (!container) return;
+  container.innerHTML = `
+    <span class="status-badge">Tektronix Série 3</span>
+    <h3>Oscilloscope numérique 4 voies</h3>
+    <p>
+      Visualisez vos signaux avec une précision professionnelle. Le rendu ci-dessous simule la persistance
+      et la grille d'un oscilloscope Tektronix moderne.
+    </p>
+    <div class="instrument-display" aria-live="polite">
+      <canvas class="oscilloscope-display" width="600" height="220" role="img"
+        aria-label="Affichage de la forme d'onde"></canvas>
+    </div>
+    <div class="instrument-controls">
+      <label>
+        Forme d'onde
+        <select id="oscilloscope-waveform"></select>
+      </label>
+      <label>
+        Amplitude
+        <input id="oscilloscope-amplitude" type="range" min="0.2" max="1.4" step="0.1" value="1">
+      </label>
+      <label>
+        Décalage
+        <input id="oscilloscope-offset" type="range" min="-0.6" max="0.6" step="0.1" value="0">
+      </label>
+      <label>
+        Base de temps
+        <span id="oscilloscope-timebase" aria-live="polite">1.0 ms/div</span>
+      </label>
+    </div>
+  `;
+
+  const canvas = container.querySelector('canvas');
+  const waveformSelect = container.querySelector('#oscilloscope-waveform');
+  const amplitudeRange = container.querySelector('#oscilloscope-amplitude');
+  const offsetRange = container.querySelector('#oscilloscope-offset');
+  const timebaseLabel = container.querySelector('#oscilloscope-timebase');
+
+  Object.entries(WAVEFORMS).forEach(([value, { label }]) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    waveformSelect.appendChild(option);
+  });
+  waveformSelect.value = 'sinus';
+
+  let timebase = 1;
+  let direction = -0.1;
+  const updateTimebase = () => {
+    timebase += direction;
+    if (timebase <= 0.2 || timebase >= 5) {
+      direction *= -1;
+    }
+    timebaseLabel.textContent = formatTimebase(timebase);
+  };
+
+  const draw = () => {
+    const currentWaveform = WAVEFORMS[waveformSelect.value] || WAVEFORMS.sinus;
+    drawWaveform(canvas, {
+      waveform: currentWaveform.generator,
+      amplitude: parseFloat(amplitudeRange.value),
+      offset: parseFloat(offsetRange.value)
+    });
+  };
+
+  draw();
+  const redraw = () => {
+    draw();
+  };
+
+  waveformSelect.addEventListener('change', redraw);
+  amplitudeRange.addEventListener('input', redraw);
+  offsetRange.addEventListener('input', redraw);
+
+  setInterval(() => {
+    updateTimebase();
+    draw();
+  }, 1200);
+}


### PR DESCRIPTION
## Summary
- add a dedicated entry point on the main dashboard with a Virtual Lab logo
- build a new Virtual Lab page with Tektronix-style oscilloscope, laboratory multimeter, function generator, and math tools
- separate HTML, CSS, JavaScript, and assets for easier maintenance of the virtual instruments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc0c262024832eb4e1987a61f06896