### PR TITLE
Refonte du laboratoire virtuel en quadrillage 4 zones

### DIFF
--- a/data/virtual-lab/css/style.css
+++ b/data/virtual-lab/css/style.css
@@ -1,303 +1,564 @@
 :root {
-  --primary: #0a6dd8;
-  --primary-dark: #06488f;
-  --accent: #45d1ff;
-  --background: #0f172a;
-  --surface: rgba(15, 23, 42, 0.88);
-  --surface-light: rgba(255, 255, 255, 0.04);
+  --bg-top: #040b1e;
+  --bg-bottom: #02040d;
+  --surface: rgba(12, 19, 38, 0.92);
+  --surface-highlight: rgba(20, 32, 58, 0.92);
+  --surface-screen: rgba(2, 10, 22, 0.88);
+  --surface-screen-glow: rgba(20, 209, 255, 0.08);
+  --divider: rgba(148, 163, 184, 0.2);
+  --accent: #4ad4ff;
+  --accent-strong: #00b1ff;
+  --accent-warm: #ffb347;
   --text: #f8fafc;
-  --text-muted: #94a3b8;
-  --divider: rgba(148, 163, 184, 0.3);
-  font-family: 'Segoe UI', Roboto, Arial, sans-serif;
+  --text-muted: #8aa0c2;
+  --text-soft: rgba(226, 232, 240, 0.75);
+  --shadow: 0 28px 60px rgba(2, 8, 24, 0.65);
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(69, 209, 255, 0.16), transparent 60%),
-              linear-gradient(135deg, #050816 0%, #0f172a 55%, #020617 100%);
+  min-height: 100%;
+  height: 100%;
+  background: radial-gradient(circle at 10% 5%, rgba(74, 212, 255, 0.18), transparent 35%),
+              radial-gradient(circle at 85% 15%, rgba(255, 179, 71, 0.12), transparent 36%),
+              linear-gradient(160deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
   color: var(--text);
 }
 
-.page {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 3.5rem 1.5rem 4rem;
-}
-
-header {
+body {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 3rem;
+  align-items: stretch;
+  justify-content: stretch;
 }
 
-header a {
-  color: var(--text-muted);
-  text-decoration: none;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  transition: color 0.2s ease;
-}
-
-header a:hover {
-  color: var(--accent);
-}
-
-.hero {
-  background: var(--surface);
-  border: 1px solid var(--divider);
-  border-radius: 24px;
-  padding: 2rem;
+.lab-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  width: 100%;
+  height: 100vh;
   gap: 1.5rem;
-  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.55);
-}
-
-.hero-visual {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1rem;
-}
-
-.hero-visual img {
-  width: min(220px, 100%);
-  height: auto;
-  filter: drop-shadow(0 18px 28px rgba(4, 12, 40, 0.45));
-}
-
-.hero-content h1 {
-  font-size: clamp(2rem, 4vw, 2.9rem);
-  margin: 0 0 1rem;
-}
-
-.hero-content p {
-  margin: 0 0 1.5rem;
-  line-height: 1.6;
-  color: var(--text-muted);
-}
-
-.hero-content .cta {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.75rem 1.4rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--primary), var(--accent));
-  color: #0b1120;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.hero-content .cta:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 28px rgba(69, 209, 255, 0.25);
-}
-
-.section-title {
-  margin: 3rem 0 1rem;
-  font-size: 1.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-muted);
-}
-
-.instrument-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-}
-
-.instrument-card {
-  background: var(--surface);
-  border: 1px solid var(--divider);
-  border-radius: 20px;
   padding: 1.5rem;
+}
+
+.zone {
+  position: relative;
+  padding: 1rem;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  border-radius: 26px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(9, 17, 35, 0.55));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.zone::before {
+  content: "";
+  position: absolute;
+  inset: 1.5rem;
+  border-radius: 20px;
+  opacity: 0.35;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  transition: opacity 0.2s ease;
+}
+
+.zone-oscilloscope::before { background: radial-gradient(circle at 30% 30%, rgba(74, 212, 255, 0.35), transparent 60%); }
+.zone-generator::before { background: radial-gradient(circle at 80% 35%, rgba(255, 179, 71, 0.3), transparent 65%); }
+.zone-multimeter::before { background: radial-gradient(circle at 40% 70%, rgba(88, 255, 155, 0.25), transparent 62%); }
+.zone-math::before { background: radial-gradient(circle at 60% 45%, rgba(168, 140, 255, 0.28), transparent 70%); }
+
+.zone:hover::before {
+  opacity: 0.55;
+}
+
+.device {
+  flex: 1;
+  display: flex;
+}
+
+.device-shell {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.instrument-card h3 {
-  font-size: 1.2rem;
-  margin: 0;
-}
-
-.instrument-card p {
-  margin: 0;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.instrument-display {
-  background: var(--surface-light);
-  border: 1px solid var(--divider);
-  border-radius: 16px;
-  padding: 1rem;
-  min-height: 160px;
+  gap: 1.25rem;
+  width: 100%;
+  border-radius: 22px;
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
   position: relative;
   overflow: hidden;
 }
 
-.instrument-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+.device-shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 22px;
+  pointer-events: none;
+  border: 1px solid rgba(255, 255, 255, 0.02);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.015);
 }
 
-.instrument-controls label {
+.device-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.device-branding {
   display: flex;
   flex-direction: column;
-  font-size: 0.8rem;
+  gap: 0.35rem;
+}
+
+.device-brand {
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.48em;
+  font-size: 0.72rem;
   color: var(--text-muted);
-  gap: 0.4rem;
 }
 
-.instrument-controls select,
-.instrument-controls input {
-  background: rgba(15, 23, 42, 0.65);
-  color: var(--text);
-  border: 1px solid var(--divider);
-  border-radius: 999px;
-  padding: 0.45rem 0.8rem;
-  min-width: 120px;
-  font-size: 0.9rem;
+.device-model {
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
-.instrument-controls progress {
-  width: 180px;
-  height: 12px;
-  -webkit-appearance: none;
-  appearance: none;
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid var(--divider);
+.device-subtitle {
+  font-size: 0.95rem;
+  color: var(--text-soft);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.instrument-controls progress::-webkit-progress-bar {
-  background: transparent;
-}
-
-.instrument-controls progress::-webkit-progress-value {
-  background: linear-gradient(135deg, var(--accent), var(--primary));
-}
-
-.instrument-controls progress::-moz-progress-bar {
-  background: linear-gradient(135deg, var(--accent), var(--primary));
-}
-
-.math-zone {
-  background: linear-gradient(145deg, rgba(10, 109, 216, 0.22), rgba(69, 209, 255, 0.08));
-  border-radius: 20px;
-  padding: 1.5rem;
-  border: 1px solid rgba(69, 209, 255, 0.28);
+.io-selector {
   display: flex;
   flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+  min-width: 180px;
+}
+
+.io-selector label {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.io-select,
+.device-shell select,
+.device-shell input,
+.device-shell button {
+  font-family: inherit;
+}
+
+.io-select {
+  background: rgba(5, 12, 28, 0.92);
+  color: var(--text);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.55rem 1rem;
+  font-size: 0.95rem;
+  min-width: 160px;
+  appearance: none;
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.io-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.device-status {
+  min-height: 1.2rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Oscilloscope ---------------------------------------------------------- */
+
+.oscilloscope-shell {
+  gap: 1.75rem;
+}
+
+.oscilloscope-body {
+  display: flex;
+  gap: 1.5rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.oscilloscope-screen {
+  flex: 1.35;
+  background: linear-gradient(145deg, rgba(3, 15, 28, 0.85), rgba(10, 28, 42, 0.95));
+  border-radius: 18px;
+  border: 1px solid rgba(69, 209, 255, 0.18);
+  position: relative;
+  padding: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(69, 209, 255, 0.12), inset 0 18px 48px rgba(12, 72, 110, 0.35);
+}
+
+.oscilloscope-screen::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 45%, rgba(69, 209, 255, 0.15), transparent 65%);
+  pointer-events: none;
+}
+
+.oscilloscope-display {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 12px;
+  border: 1px solid rgba(69, 209, 255, 0.2);
+  overflow: hidden;
+}
+
+.oscilloscope-display canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.oscilloscope-readout {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: rgba(209, 250, 255, 0.75);
+}
+
+.oscilloscope-controls {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
 }
 
-.math-zone h3 {
+.oscilloscope-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.oscilloscope-controls input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+/* Function generator ---------------------------------------------------- */
+
+.generator-shell {
+  gap: 1.5rem;
+}
+
+.generator-body {
+  display: flex;
+  gap: 1.35rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.generator-visual {
+  flex: 1.15;
+  background: linear-gradient(155deg, rgba(8, 18, 30, 0.9), rgba(25, 30, 48, 0.9));
+  border-radius: 18px;
+  border: 1px solid rgba(255, 179, 71, 0.2);
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: inset 0 14px 48px rgba(255, 179, 71, 0.15);
+}
+
+.generator-visual canvas {
+  width: 100%;
+  height: 160px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 179, 71, 0.25);
+}
+
+.generator-summary {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 206, 158, 0.8);
+  padding-top: 0.25rem;
+}
+
+.generator-controls {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.generator-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.generator-controls input[type="range"],
+.generator-controls select {
+  width: 100%;
+}
+
+.generator-controls input[type="range"] {
+  accent-color: var(--accent-warm);
+}
+
+/* Multimeter ------------------------------------------------------------ */
+
+.multimeter-shell {
+  gap: 1.4rem;
+}
+
+.multimeter-display {
+  background: linear-gradient(180deg, rgba(10, 26, 24, 0.95), rgba(5, 14, 12, 0.88));
+  border-radius: 18px;
+  border: 1px solid rgba(56, 143, 123, 0.28);
+  padding: 1.5rem 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: flex-start;
+  box-shadow: inset 0 22px 48px rgba(56, 143, 123, 0.12);
+}
+
+.multimeter-readout {
+  font-family: "Segment7Standard", "Share Tech Mono", "Roboto Mono", monospace;
+  font-size: clamp(2.2rem, 3vw, 3rem);
+  letter-spacing: 0.18em;
+  color: #7df9a9;
+  text-shadow: 0 0 12px rgba(125, 249, 169, 0.45);
+}
+
+.multimeter-unit {
+  font-size: 1rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: rgba(125, 249, 169, 0.8);
+}
+
+.multimeter-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.multimeter-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.multimeter-controls progress {
+  width: 100%;
+  height: 14px;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 999px;
+  border: 1px solid rgba(125, 249, 169, 0.28);
+  overflow: hidden;
+}
+
+.multimeter-controls progress::-webkit-progress-bar {
+  background: transparent;
+}
+
+.multimeter-controls progress::-webkit-progress-value {
+  background: linear-gradient(135deg, rgba(125, 249, 169, 0.2), rgba(125, 249, 169, 0.65));
+}
+
+.multimeter-controls progress::-moz-progress-bar {
+  background: linear-gradient(135deg, rgba(125, 249, 169, 0.2), rgba(125, 249, 169, 0.65));
+}
+
+/* Math zone ------------------------------------------------------------- */
+
+.math-shell {
+  gap: 1.3rem;
+}
+
+.math-console {
+  flex: 1;
+  background: linear-gradient(160deg, rgba(16, 12, 32, 0.92), rgba(9, 7, 24, 0.92));
+  border-radius: 18px;
+  border: 1px solid rgba(164, 148, 255, 0.25);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: inset 0 18px 48px rgba(164, 148, 255, 0.18);
+}
+
+.math-console h3 {
   margin: 0;
-  font-size: 1.3rem;
+  font-size: 1.35rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.math-console p {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.6;
 }
 
 .math-input {
   display: flex;
-  flex-wrap: wrap;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .math-input input {
-  flex: 1;
-  min-width: 220px;
-  border-radius: 999px;
-  border: 1px solid rgba(69, 209, 255, 0.32);
-  background: rgba(15, 23, 42, 0.65);
-  color: var(--text);
-  padding: 0.6rem 1rem;
+  flex: 1 1 220px;
+  background: rgba(6, 9, 22, 0.85);
+  border-radius: 14px;
+  border: 1px solid rgba(164, 148, 255, 0.32);
+  padding: 0.7rem 1rem;
   font-size: 1rem;
+  color: var(--text);
 }
 
 .math-input button {
+  background: linear-gradient(135deg, rgba(164, 148, 255, 0.85), rgba(102, 126, 234, 0.95));
   border: none;
-  border-radius: 999px;
-  padding: 0.6rem 1.5rem;
-  font-weight: 700;
-  text-transform: uppercase;
+  border-radius: 14px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
   letter-spacing: 0.1em;
-  background: linear-gradient(135deg, var(--accent), var(--primary));
-  color: #0b1120;
+  text-transform: uppercase;
+  color: #0a0f20;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28);
 }
 
 .math-input button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 15px 25px rgba(69, 209, 255, 0.22);
 }
 
 .math-result {
-  font-size: 1.1rem;
-  color: var(--accent);
-  min-height: 1.4em;
-}
-
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(69, 209, 255, 0.08);
-  border: 1px solid rgba(69, 209, 255, 0.32);
-  font-size: 0.75rem;
+  min-height: 1.5rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--accent);
+  color: rgba(199, 190, 255, 0.9);
 }
 
-canvas.oscilloscope-display {
-  width: 100%;
-  height: 100%;
+.math-console ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-soft);
+  line-height: 1.6;
 }
 
-.measurement-value {
-  font-size: 2rem;
-  font-weight: 700;
+.math-console li::marker {
+  color: rgba(164, 148, 255, 0.6);
 }
 
-.measurement-unit {
-  color: var(--text-muted);
+/* Noscript -------------------------------------------------------------- */
+
+.noscript {
+  position: fixed;
+  inset: 1.5rem;
+  border-radius: 16px;
+  background: rgba(255, 87, 87, 0.1);
+  color: #ff7b7b;
+  border: 1px solid rgba(255, 87, 87, 0.35);
+  padding: 1rem 1.5rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+}
+
+/* Generic form tweaks --------------------------------------------------- */
+
+.device-shell input[type="range"] {
+  cursor: pointer;
+}
+
+.device-shell input,
+.device-shell select {
+  color-scheme: dark;
+}
+
+.device-shell button:focus,
+.device-shell input:focus,
+.device-shell select:focus {
+  outline: 2px solid rgba(74, 212, 255, 0.55);
+  outline-offset: 2px;
+}
+
+@media (max-width: 1280px) {
+  .lab-grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-auto-rows: minmax(360px, 1fr);
+    height: auto;
+  }
+
+  .zone {
+    min-height: 360px;
+  }
+}
+
+@media (max-width: 820px) {
+  .device-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .io-selector {
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 640px) {
-  .page {
-    padding: 2.5rem 1.1rem 3rem;
+  body {
+    padding: 0 0 2rem;
   }
 
-  header {
-    flex-direction: column;
-    align-items: flex-start;
+  .lab-grid {
     gap: 1rem;
+    padding: 1rem;
   }
 
-  .hero {
-    padding: 1.5rem;
+  .zone {
+    padding: 0.6rem;
+  }
+
+  .device-shell {
+    padding: 1.2rem;
   }
 }

--- a/data/virtual-lab/index.html
+++ b/data/virtual-lab/index.html
@@ -7,39 +7,26 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <div class="page">
-    <header>
-      <a href="../index.html" class="return-link" aria-label="Retour à l'accueil">
-        &#x2190; Retour au tableau de bord
-      </a>
-      <span class="status-badge">Environnement virtuel</span>
-    </header>
-
-    <section class="hero">
-      <div class="hero-visual">
-        <img src="../assets/virtual-lab-logo.svg" alt="Logo Virtual Lab MiniLabBox">
-      </div>
-      <div class="hero-content">
-        <h1>Virtual Lab Professionnel</h1>
-        <p>
-          Retrouvez vos instruments de mesure dans une interface immersive inspirée des laboratoires modernes.
-          Configurez l'oscilloscope, le multimètre et le générateur de fonctions comme si vous étiez devant le matériel.
-        </p>
-        <a class="cta" href="#lab">Explorer le laboratoire</a>
-      </div>
+  <div class="lab-grid" role="main">
+    <section class="zone zone-oscilloscope" aria-labelledby="oscilloscope-title">
+      <div class="device" id="oscilloscope"></div>
     </section>
-
-    <h2 class="section-title" id="lab">Instruments</h2>
-    <section class="instrument-grid">
-      <article class="instrument-card" id="oscilloscope"></article>
-      <article class="instrument-card" id="multimeter"></article>
-      <article class="instrument-card" id="function-generator"></article>
+    <section class="zone zone-generator" aria-labelledby="function-generator-title">
+      <div class="device" id="function-generator"></div>
     </section>
-
-    <h2 class="section-title">Zone mathématique</h2>
-    <section class="math-zone" id="math-zone"></section>
+    <section class="zone zone-multimeter" aria-labelledby="multimeter-title">
+      <div class="device" id="multimeter"></div>
+    </section>
+    <section class="zone zone-math" aria-labelledby="math-zone-title">
+      <div class="device" id="math-zone"></div>
+    </section>
   </div>
 
+  <noscript>
+    <div class="noscript">Activez JavaScript pour accéder au laboratoire virtuel.</div>
+  </noscript>
+
+  <script src="../auth.js"></script>
   <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/data/virtual-lab/js/ioCatalog.js
+++ b/data/virtual-lab/js/ioCatalog.js
@@ -1,0 +1,132 @@
+const DEFAULT_INPUT_FALLBACK = (index) => `IN${index + 1}`;
+const DEFAULT_OUTPUT_FALLBACK = (index) => `OUT${index + 1}`;
+
+function normaliseNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const num = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normaliseName(name, fallbackFactory, index) {
+  if (name && typeof name === 'string' && name.trim().length) {
+    return name.trim();
+  }
+  return fallbackFactory(index);
+}
+
+async function ensureAuthSession() {
+  if (typeof window.ensureSession === 'function') {
+    try {
+      await window.ensureSession();
+    } catch (err) {
+      console.warn('[VirtualLab] Session check failed:', err);
+    }
+  }
+}
+
+function getFetcher() {
+  if (typeof window.authFetch === 'function') {
+    return window.authFetch.bind(window);
+  }
+  return (url, options = {}) => fetch(url, { credentials: 'include', ...options });
+}
+
+async function fetchJson(url) {
+  const response = await getFetcher()(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    const message = await response.text().catch(() => '');
+    throw new Error(message || `Requête HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function loadIoCatalog() {
+  await ensureAuthSession();
+  try {
+    const config = await fetchJson('/api/config/get');
+    const inputs = Array.isArray(config.inputs)
+      ? config.inputs
+          .map((item, index) => ({ item, index }))
+          .filter(({ item }) => item && (item.active ?? true))
+          .map(({ item, index }) => ({
+            name: normaliseName(item.name, DEFAULT_INPUT_FALLBACK, index),
+            unit: item.unit || '',
+            type: item.type || 'unknown',
+            scale: normaliseNumber(item.scale),
+            offset: normaliseNumber(item.offset)
+          }))
+      : [];
+    const outputs = Array.isArray(config.outputs)
+      ? config.outputs
+          .map((item, index) => ({ item, index }))
+          .filter(({ item }) => item && (item.active ?? true))
+          .map(({ item, index }) => ({
+            name: normaliseName(item.name, DEFAULT_OUTPUT_FALLBACK, index),
+            type: item.type || 'unknown',
+            scale: normaliseNumber(item.scale),
+            offset: normaliseNumber(item.offset)
+          }))
+      : [];
+    return { inputs, outputs, error: null };
+  } catch (error) {
+    console.warn('[VirtualLab] Chargement configuration IO impossible:', error);
+    return { inputs: [], outputs: [], error };
+  }
+}
+
+export async function fetchInputsSnapshot() {
+  await ensureAuthSession();
+  try {
+    const data = await fetchJson('/api/inputs');
+    const map = {};
+    if (data && Array.isArray(data.inputs)) {
+      data.inputs.forEach((entry) => {
+        if (entry && entry.name) {
+          map[entry.name] = normaliseNumber(entry.value);
+        }
+      });
+    }
+    return map;
+  } catch (error) {
+    console.warn('[VirtualLab] Lecture des entrées impossible:', error);
+    throw error;
+  }
+}
+
+export async function fetchOutputsSnapshot() {
+  await ensureAuthSession();
+  try {
+    const data = await fetchJson('/api/outputs');
+    const map = {};
+    if (data && Array.isArray(data.outputs)) {
+      data.outputs.forEach((entry) => {
+        if (entry && entry.name) {
+          map[entry.name] = {
+            value: normaliseNumber(entry.value),
+            active: !!entry.active
+          };
+        }
+      });
+    }
+    return map;
+  } catch (error) {
+    console.warn('[VirtualLab] Lecture des sorties impossible:', error);
+    throw error;
+  }
+}
+
+export async function sendOutputValue(name, value) {
+  await ensureAuthSession();
+  const response = await getFetcher()('/api/output/set', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, value })
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(text || `Écriture sortie refusée (${response.status})`);
+  }
+  return response.json().catch(() => ({}));
+}

--- a/data/virtual-lab/js/main.js
+++ b/data/virtual-lab/js/main.js
@@ -2,10 +2,14 @@ import { mountOscilloscope } from './oscilloscope.js';
 import { mountMultimeter } from './multimeter.js';
 import { mountFunctionGenerator } from './functionGenerator.js';
 import { mountMathZone } from './mathZone.js';
+import { loadIoCatalog } from './ioCatalog.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  mountOscilloscope(document.getElementById('oscilloscope'));
-  mountMultimeter(document.getElementById('multimeter'));
-  mountFunctionGenerator(document.getElementById('function-generator'));
+document.addEventListener('DOMContentLoaded', async () => {
+  const catalog = await loadIoCatalog();
+  const { inputs, outputs, error } = catalog;
+
+  mountOscilloscope(document.getElementById('oscilloscope'), { inputs, error });
+  mountMultimeter(document.getElementById('multimeter'), { inputs, error });
+  mountFunctionGenerator(document.getElementById('function-generator'), { outputs, error });
   mountMathZone(document.getElementById('math-zone'));
 });

--- a/data/virtual-lab/js/mathZone.js
+++ b/data/virtual-lab/js/mathZone.js
@@ -22,21 +22,32 @@ function safeEval(expression) {
 export function mountMathZone(container) {
   if (!container) return;
   container.innerHTML = `
-    <div>
-      <h3>Calculs rapides</h3>
-      <p>
-        Évaluez instantanément vos formules : rapports de division, conversions d'unités ou calculs de puissance.
-        La zone est isolée pour simplifier la maintenance du code.
-      </p>
-    </div>
-    <div class="math-input">
-      <input type="text" id="math-expression" placeholder="Exemple : (5.0/2) * Math.PI" aria-label="Expression mathématique">
-      <button type="button" id="math-run">Calculer</button>
-    </div>
-    <div class="math-result" id="math-result" aria-live="polite"></div>
-    <div>
-      <h4>Idées de calculs</h4>
-      <ul>${renderExamples(EXAMPLES)}</ul>
+    <div class="device-shell math-shell">
+      <div class="device-header">
+        <div class="device-branding">
+          <span class="device-brand">Analyse</span>
+          <span class="device-model" id="math-zone-title">Console mathématique</span>
+          <span class="device-subtitle">Calculs temps réel</span>
+        </div>
+      </div>
+      <div class="math-console">
+        <div>
+          <h3>Calculs rapides</h3>
+          <p>
+            Évaluez instantanément vos formules : rapports de division, conversions d'unités ou calculs de puissance.
+            La console est isolée pour simplifier la maintenance du code.
+          </p>
+        </div>
+        <div class="math-input">
+          <input type="text" id="math-expression" placeholder="Exemple : (5.0/2) * Math.PI" aria-label="Expression mathématique">
+          <button type="button" id="math-run">Calculer</button>
+        </div>
+        <div class="math-result" id="math-result" aria-live="polite"></div>
+        <div>
+          <h4>Idées de calculs</h4>
+          <ul>${renderExamples(EXAMPLES)}</ul>
+        </div>
+      </div>
     </div>
   `;
 

--- a/data/virtual-lab/js/multimeter.js
+++ b/data/virtual-lab/js/multimeter.js
@@ -1,3 +1,5 @@
+import { fetchInputsSnapshot } from './ioCatalog.js';
+
 const MEASUREMENTS = {
   voltage: { label: 'Tension DC', unit: 'V', range: [3.28, 3.34] },
   voltageAc: { label: 'Tension AC', unit: 'V RMS', range: [229.2, 231.5] },
@@ -9,36 +11,70 @@ function randomInRange([min, max]) {
   return Math.random() * (max - min) + min;
 }
 
-function formatValue(value) {
-  return value.toFixed(3).replace('.', ',');
+function formatValue(value, digits = 3) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return Number(value).toFixed(digits).replace('.', ',');
 }
 
-export function mountMultimeter(container) {
+function populateSelect(select, options, placeholder) {
+  select.innerHTML = '';
+  if (!options.length) {
+    const opt = document.createElement('option');
+    opt.textContent = placeholder;
+    opt.value = '';
+    select.appendChild(opt);
+    select.disabled = true;
+    return;
+  }
+  options.forEach((item) => {
+    const opt = document.createElement('option');
+    opt.value = item.name;
+    opt.textContent = item.name;
+    select.appendChild(opt);
+  });
+  select.disabled = false;
+}
+
+export function mountMultimeter(container, { inputs = [], error = null } = {}) {
   if (!container) return;
   container.innerHTML = `
-    <span class="status-badge">DMM de laboratoire</span>
-    <h3>Multimètre 6½ digits</h3>
-    <p>
-      Mesurez avec stabilité et précision. La simulation reproduit une lecture typique d'un multimètre
-      de paillasse haut de gamme avec filtrage numérique.
-    </p>
-    <div class="instrument-display" role="img" aria-label="Affichage de mesure">
-      <div class="measurement-value" id="multimeter-value">0,000</div>
-      <div class="measurement-unit" id="multimeter-unit">V</div>
-    </div>
-    <div class="instrument-controls">
-      <label>
-        Mode
-        <select id="multimeter-mode"></select>
-      </label>
-      <label>
-        Filtre numérique
-        <input type="range" id="multimeter-filter" min="0" max="100" value="40">
-      </label>
-      <label>
-        Barregraph
-        <progress id="multimeter-bar" max="100" value="30" aria-label="Barregraph numérique"></progress>
-      </label>
+    <div class="device-shell multimeter-shell">
+      <div class="device-header">
+        <div class="device-branding">
+          <span class="device-brand">Keysight</span>
+          <span class="device-model" id="multimeter-title">34470A</span>
+          <span class="device-subtitle">Multimètre 6½ digits</span>
+        </div>
+        <div class="io-selector">
+          <label for="multimeter-input">Entrée mesurée</label>
+          <select id="multimeter-input" class="io-select"></select>
+        </div>
+      </div>
+      <div class="device-status" id="multimeter-status"></div>
+      <div class="multimeter-display" role="img" aria-label="Affichage de mesure">
+        <div class="multimeter-readout" id="multimeter-value">0,000</div>
+        <div class="multimeter-unit" id="multimeter-unit">V</div>
+      </div>
+      <div class="multimeter-controls">
+        <label>
+          Mode
+          <select id="multimeter-mode" class="io-select"></select>
+        </label>
+        <label>
+          Filtre numérique
+          <input type="range" id="multimeter-filter" min="0" max="100" value="40">
+        </label>
+        <label>
+          Barregraph
+          <progress id="multimeter-bar" max="100" value="30" aria-label="Barregraph numérique"></progress>
+        </label>
+        <label>
+          Dernière lecture
+          <span id="multimeter-updated">—</span>
+        </label>
+      </div>
     </div>
   `;
 
@@ -47,6 +83,20 @@ export function mountMultimeter(container) {
   const unitDisplay = container.querySelector('#multimeter-unit');
   const filterRange = container.querySelector('#multimeter-filter');
   const bar = container.querySelector('#multimeter-bar');
+  const updatedLabel = container.querySelector('#multimeter-updated');
+  const inputSelect = container.querySelector('#multimeter-input');
+  const statusLabel = container.querySelector('#multimeter-status');
+
+  populateSelect(inputSelect, inputs, 'Aucune entrée active');
+  const ioMap = new Map(inputs.map((item) => [item.name, item]));
+  if (inputs.length) {
+    inputSelect.value = inputs[0].name;
+    statusLabel.textContent = `${inputs.length} entrée(s) disponibles`;
+  } else if (error) {
+    statusLabel.textContent = 'Impossible de charger les entrées.';
+  } else {
+    statusLabel.textContent = 'Activez une entrée dans la configuration.';
+  }
 
   Object.entries(MEASUREMENTS).forEach(([key, { label }]) => {
     const option = document.createElement('option');
@@ -55,35 +105,97 @@ export function mountMultimeter(container) {
     modeSelect.appendChild(option);
   });
 
-  let previousValue = null;
+  const state = {
+    previousValue: null,
+    timer: null
+  };
+
   const getSmoothedValue = (raw, smoothing) => {
-    if (previousValue === null) {
-      previousValue = raw;
+    if (raw === null) {
+      return null;
+    }
+    if (state.previousValue === null || Number.isNaN(state.previousValue)) {
+      state.previousValue = raw;
       return raw;
     }
     const alpha = Math.max(0.02, 1 - smoothing);
-    previousValue = previousValue + (raw - previousValue) * alpha;
-    return previousValue;
+    state.previousValue = state.previousValue + (raw - state.previousValue) * alpha;
+    return state.previousValue;
   };
 
-  const updateDisplay = () => {
-    const { range, unit } = MEASUREMENTS[modeSelect.value] || MEASUREMENTS.voltage;
-    const rawValue = randomInRange(range);
-    const smoothing = parseInt(filterRange.value, 10) / 100;
-    const value = getSmoothedValue(rawValue, smoothing);
+  const updateDisplay = (value, metadata) => {
+    const { unit, range } = metadata;
     valueDisplay.textContent = formatValue(value);
     unitDisplay.textContent = unit;
-    bar.value = Math.min(100, Math.max(0, ((value - range[0]) / (range[1] - range[0])) * 100));
+    if (value === null || !range || range[0] === range[1]) {
+      bar.value = 0;
+    } else {
+      const percent = ((value - range[0]) / (range[1] - range[0])) * 100;
+      bar.value = Math.min(100, Math.max(0, percent));
+    }
+  };
+
+  const refreshMeasurement = async () => {
+    const measurement = MEASUREMENTS[modeSelect.value] || MEASUREMENTS.voltage;
+    const selectedName = inputSelect.value;
+    const smoothing = parseInt(filterRange.value, 10) / 100;
+    if (!selectedName) {
+      state.previousValue = null;
+      updateDisplay(null, { unit: measurement.unit, range: measurement.range });
+      updatedLabel.textContent = '—';
+      return;
+    }
+    try {
+      const snapshot = await fetchInputsSnapshot();
+      const raw = Object.prototype.hasOwnProperty.call(snapshot, selectedName)
+        ? snapshot[selectedName]
+        : null;
+      const value = raw !== null ? getSmoothedValue(raw, smoothing) : null;
+      const ioInfo = ioMap.get(selectedName);
+      const unit = (ioInfo && ioInfo.unit) || measurement.unit;
+      updateDisplay(value, { unit, range: measurement.range });
+      const now = new Date();
+      updatedLabel.textContent = now.toLocaleTimeString('fr-FR', { hour12: false });
+      statusLabel.textContent = raw === null
+        ? `Lecture indisponible pour ${selectedName}`
+        : `Lecture en cours sur ${selectedName}`;
+    } catch (err) {
+      statusLabel.textContent = 'Erreur lors de la lecture des entrées';
+      const fallbackValue = getSmoothedValue(randomInRange(measurement.range), smoothing);
+      updateDisplay(fallbackValue, { unit: measurement.unit, range: measurement.range });
+      updatedLabel.textContent = '—';
+    }
+  };
+
+  const scheduleRefresh = () => {
+    if (state.timer) {
+      clearInterval(state.timer);
+    }
+    state.timer = setInterval(refreshMeasurement, 1200);
   };
 
   modeSelect.addEventListener('change', () => {
-    previousValue = null;
-    updateDisplay();
+    state.previousValue = null;
+    refreshMeasurement();
   });
 
-  filterRange.addEventListener('input', updateDisplay);
+  filterRange.addEventListener('input', () => {
+    state.previousValue = null;
+    refreshMeasurement();
+  });
+
+  inputSelect.addEventListener('change', () => {
+    state.previousValue = null;
+    refreshMeasurement();
+  });
+
+  window.addEventListener('beforeunload', () => {
+    if (state.timer) {
+      clearInterval(state.timer);
+    }
+  });
 
   modeSelect.value = 'voltage';
-  updateDisplay();
-  setInterval(updateDisplay, 1100);
+  refreshMeasurement();
+  scheduleRefresh();
 }

--- a/data/virtual-lab/js/oscilloscope.js
+++ b/data/virtual-lab/js/oscilloscope.js
@@ -17,18 +17,21 @@ function formatTimebase(value) {
   if (value < 1) {
     return `${(value * 1000).toFixed(0)} µs/div`;
   }
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(2)} s/div`;
+  }
   return `${value.toFixed(1)} ms/div`;
 }
 
 function drawWaveform(canvas, options) {
   const ctx = canvas.getContext('2d');
-  const { waveform, amplitude, offset } = options;
+  const { waveform, amplitude, offset, intensity } = options;
   const { width, height } = canvas;
 
   ctx.clearRect(0, 0, width, height);
 
-  ctx.strokeStyle = 'rgba(148, 163, 184, 0.3)';
   ctx.lineWidth = 1;
+  ctx.strokeStyle = 'rgba(96, 165, 250, 0.25)';
   const divisions = 8;
   for (let i = 1; i < divisions; i += 1) {
     const x = (width / divisions) * i;
@@ -43,10 +46,10 @@ function drawWaveform(canvas, options) {
     ctx.stroke();
   }
 
-  ctx.strokeStyle = '#45d1ff';
-  ctx.lineWidth = 2;
+  ctx.strokeStyle = `rgba(69, 209, 255, ${intensity})`;
+  ctx.lineWidth = 2.2;
   ctx.beginPath();
-  const samples = 600;
+  const samples = 640;
   for (let i = 0; i <= samples; i += 1) {
     const ratio = i / samples;
     const x = ratio * width;
@@ -62,36 +65,71 @@ function drawWaveform(canvas, options) {
   ctx.stroke();
 }
 
-export function mountOscilloscope(container) {
+function populateSelect(select, options, placeholder) {
+  select.innerHTML = '';
+  if (!options.length) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = placeholder;
+    select.appendChild(opt);
+    select.disabled = true;
+    return;
+  }
+  options.forEach((item) => {
+    const opt = document.createElement('option');
+    opt.value = item.name;
+    opt.textContent = item.name;
+    select.appendChild(opt);
+  });
+  select.disabled = false;
+}
+
+export function mountOscilloscope(container, { inputs = [], error = null } = {}) {
   if (!container) return;
   container.innerHTML = `
-    <span class="status-badge">Tektronix Série 3</span>
-    <h3>Oscilloscope numérique 4 voies</h3>
-    <p>
-      Visualisez vos signaux avec une précision professionnelle. Le rendu ci-dessous simule la persistance
-      et la grille d'un oscilloscope Tektronix moderne.
-    </p>
-    <div class="instrument-display" aria-live="polite">
-      <canvas class="oscilloscope-display" width="600" height="220" role="img"
-        aria-label="Affichage de la forme d'onde"></canvas>
-    </div>
-    <div class="instrument-controls">
-      <label>
-        Forme d'onde
-        <select id="oscilloscope-waveform"></select>
-      </label>
-      <label>
-        Amplitude
-        <input id="oscilloscope-amplitude" type="range" min="0.2" max="1.4" step="0.1" value="1">
-      </label>
-      <label>
-        Décalage
-        <input id="oscilloscope-offset" type="range" min="-0.6" max="0.6" step="0.1" value="0">
-      </label>
-      <label>
-        Base de temps
-        <span id="oscilloscope-timebase" aria-live="polite">1.0 ms/div</span>
-      </label>
+    <div class="device-shell oscilloscope-shell">
+      <div class="device-header">
+        <div class="device-branding">
+          <span class="device-brand">Tektronix</span>
+          <span class="device-model" id="oscilloscope-title">Série 3 MSO</span>
+          <span class="device-subtitle">Oscilloscope numérique quatre voies</span>
+        </div>
+        <div class="io-selector">
+          <label for="oscilloscope-channel">Entrée active</label>
+          <select id="oscilloscope-channel" class="io-select"></select>
+        </div>
+      </div>
+      <div class="device-status" id="oscilloscope-status"></div>
+      <div class="oscilloscope-body">
+        <div class="oscilloscope-screen">
+          <div class="oscilloscope-display">
+            <canvas class="oscilloscope-display-canvas" width="640" height="280" role="img"
+              aria-label="Affichage oscillogramme"></canvas>
+          </div>
+          <div class="oscilloscope-readout">
+            <span id="oscilloscope-readout-channel">—</span>
+            <span id="oscilloscope-readout-timebase">1.0 ms/div</span>
+          </div>
+        </div>
+        <div class="oscilloscope-controls">
+          <label>
+            Forme d'onde
+            <select id="oscilloscope-waveform" class="io-select"></select>
+          </label>
+          <label>
+            Amplitude (div)
+            <input id="oscilloscope-amplitude" type="range" min="0.2" max="1.4" step="0.1" value="1">
+          </label>
+          <label>
+            Décalage (div)
+            <input id="oscilloscope-offset" type="range" min="-0.6" max="0.6" step="0.1" value="0">
+          </label>
+          <label>
+            Intensité
+            <input id="oscilloscope-intensity" type="range" min="0.3" max="1" step="0.1" value="0.8">
+          </label>
+        </div>
+      </div>
     </div>
   `;
 
@@ -99,7 +137,22 @@ export function mountOscilloscope(container) {
   const waveformSelect = container.querySelector('#oscilloscope-waveform');
   const amplitudeRange = container.querySelector('#oscilloscope-amplitude');
   const offsetRange = container.querySelector('#oscilloscope-offset');
-  const timebaseLabel = container.querySelector('#oscilloscope-timebase');
+  const intensityRange = container.querySelector('#oscilloscope-intensity');
+  const timebaseLabel = container.querySelector('#oscilloscope-readout-timebase');
+  const channelLabel = container.querySelector('#oscilloscope-readout-channel');
+  const channelSelect = container.querySelector('#oscilloscope-channel');
+  const statusLabel = container.querySelector('#oscilloscope-status');
+
+  populateSelect(channelSelect, inputs, 'Aucune entrée active');
+  const ioMap = new Map(inputs.map((item) => [item.name, item]));
+  if (inputs.length) {
+    channelSelect.value = inputs[0].name;
+    statusLabel.textContent = `${inputs.length} voie(s) disponibles`;
+  } else if (error) {
+    statusLabel.textContent = 'Impossible de charger les entrées actives.';
+  } else {
+    statusLabel.textContent = 'Activez une entrée analogique dans la configuration.';
+  }
 
   Object.entries(WAVEFORMS).forEach(([value, { label }]) => {
     const option = document.createElement('option');
@@ -111,6 +164,7 @@ export function mountOscilloscope(container) {
 
   let timebase = 1;
   let direction = -0.1;
+
   const updateTimebase = () => {
     timebase += direction;
     if (timebase <= 0.2 || timebase >= 5) {
@@ -119,16 +173,29 @@ export function mountOscilloscope(container) {
     timebaseLabel.textContent = formatTimebase(timebase);
   };
 
+  const updateChannelLabel = () => {
+    if (!inputs.length || !channelSelect.value) {
+      channelLabel.textContent = 'Aucune entrée assignée';
+      return;
+    }
+    const selected = ioMap.get(channelSelect.value);
+    const unit = selected && selected.unit ? selected.unit : 'unités';
+    channelLabel.textContent = `${channelSelect.value} • ${parseFloat(amplitudeRange.value).toFixed(1)} div • ${unit}`;
+  };
+
   const draw = () => {
     const currentWaveform = WAVEFORMS[waveformSelect.value] || WAVEFORMS.sinus;
     drawWaveform(canvas, {
       waveform: currentWaveform.generator,
       amplitude: parseFloat(amplitudeRange.value),
-      offset: parseFloat(offsetRange.value)
+      offset: parseFloat(offsetRange.value),
+      intensity: parseFloat(intensityRange.value)
     });
+    updateChannelLabel();
   };
 
   draw();
+
   const redraw = () => {
     draw();
   };
@@ -136,6 +203,8 @@ export function mountOscilloscope(container) {
   waveformSelect.addEventListener('change', redraw);
   amplitudeRange.addEventListener('input', redraw);
   offsetRange.addEventListener('input', redraw);
+  intensityRange.addEventListener('input', redraw);
+  channelSelect.addEventListener('change', updateChannelLabel);
 
   setInterval(() => {
     updateTimebase();


### PR DESCRIPTION
## Résumé
- refonte de la page Virtual Lab pour afficher quatre zones plein écran (oscilloscope, générateur, multimètre, console mathématique)
- mise à jour complète des styles pour reproduire l’esthétique des instruments réels et disposer la grille 2x2
- ajout d’un service `ioCatalog` et adaptation des modules JS pour charger la configuration IO active, alimenter les sélecteurs et moderniser les interactions

## Tests
- Aucun test automatisé disponible pour les assets front-end

------
https://chatgpt.com/codex/tasks/task_e_68cc1431a344832e832b0517f3981329