### PR TITLE
Refonte du multimètre virtuel avec commandes réalistes

### DIFF
--- a/data/virtual-lab/css/style.css
+++ b/data/virtual-lab/css/style.css
@@ -339,71 +339,280 @@ body {
 /* Multimeter ------------------------------------------------------------ */
 
 .multimeter-shell {
-  gap: 1.4rem;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.multimeter-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1.6rem;
+}
+
+.multimeter-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 2rem;
+  align-items: stretch;
+}
+
+@media (max-width: 980px) {
+  .multimeter-body {
+    grid-template-columns: 1fr;
+  }
 }
 
 .multimeter-display {
   background: linear-gradient(180deg, rgba(10, 26, 24, 0.95), rgba(5, 14, 12, 0.88));
-  border-radius: 18px;
+  border-radius: 22px;
   border: 1px solid rgba(56, 143, 123, 0.28);
-  padding: 1.5rem 1.8rem;
+  padding: 2rem 2.2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  align-items: flex-start;
-  box-shadow: inset 0 22px 48px rgba(56, 143, 123, 0.12);
+  gap: 1.2rem;
+  align-items: stretch;
+  box-shadow: inset 0 28px 56px rgba(56, 143, 123, 0.12);
+}
+
+.multimeter-value-line {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.4rem;
 }
 
 .multimeter-readout {
   font-family: "Segment7Standard", "Share Tech Mono", "Roboto Mono", monospace;
-  font-size: clamp(2.2rem, 3vw, 3rem);
-  letter-spacing: 0.18em;
+  font-size: clamp(2.6rem, 4vw, 3.6rem);
+  letter-spacing: 0.2em;
   color: #7df9a9;
-  text-shadow: 0 0 12px rgba(125, 249, 169, 0.45);
+  text-shadow: 0 0 18px rgba(125, 249, 169, 0.5);
 }
 
-.multimeter-unit {
-  font-size: 1rem;
-  letter-spacing: 0.15em;
+.multimeter-symbol {
+  font-size: 1.25rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: rgba(125, 249, 169, 0.8);
 }
 
-.multimeter-controls {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.multimeter-controls label {
+.multimeter-display-footer {
   display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  font-size: 0.78rem;
-  letter-spacing: 0.12em;
+  align-items: center;
+  gap: 1.1rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: rgba(125, 249, 169, 0.75);
 }
 
-.multimeter-controls progress {
+.multimeter-unit {
+  font-size: 1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(125, 249, 169, 0.85);
+}
+
+.multimeter-acdc {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(125, 249, 169, 0.12);
+  border: 1px solid rgba(125, 249, 169, 0.32);
+  font-weight: 600;
+}
+
+.multimeter-hold-indicator {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(246, 198, 91, 0.18);
+  border: 1px solid rgba(246, 198, 91, 0.45);
+  color: #f6c65b;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+}
+
+.multimeter-display progress {
   width: 100%;
-  height: 14px;
+  height: 16px;
   background: rgba(0, 0, 0, 0.35);
   border-radius: 999px;
   border: 1px solid rgba(125, 249, 169, 0.28);
   overflow: hidden;
 }
 
-.multimeter-controls progress::-webkit-progress-bar {
+.multimeter-display progress::-webkit-progress-bar {
   background: transparent;
 }
 
-.multimeter-controls progress::-webkit-progress-value {
+.multimeter-display progress::-webkit-progress-value {
   background: linear-gradient(135deg, rgba(125, 249, 169, 0.2), rgba(125, 249, 169, 0.65));
 }
 
-.multimeter-controls progress::-moz-progress-bar {
+.multimeter-display progress::-moz-progress-bar {
   background: linear-gradient(135deg, rgba(125, 249, 169, 0.2), rgba(125, 249, 169, 0.65));
+}
+
+.multimeter-sidepanel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.multimeter-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.meter-button {
+  background: linear-gradient(180deg, rgba(18, 26, 32, 0.92), rgba(12, 18, 22, 0.92));
+  border: 1px solid rgba(107, 164, 182, 0.35);
+  border-radius: 12px;
+  color: rgba(225, 238, 255, 0.88);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  padding: 0.65rem 0.75rem;
+  text-transform: uppercase;
+  font-weight: 600;
+  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0);
+}
+
+.meter-button:hover,
+.meter-button:focus {
+  outline: none;
+  background: linear-gradient(180deg, rgba(28, 46, 58, 0.95), rgba(18, 32, 40, 0.95));
+}
+
+.meter-button.is-active {
+  color: #f6c65b;
+  border-color: rgba(246, 198, 91, 0.65);
+  box-shadow: inset 0 0 12px rgba(246, 198, 91, 0.35);
+}
+
+.meter-button--power.is-active {
+  color: #7df9a9;
+  border-color: rgba(125, 249, 169, 0.65);
+  box-shadow: inset 0 0 16px rgba(125, 249, 169, 0.35);
+}
+
+.meter-button--measurement {
+  font-size: 1.05rem;
+  padding-block: 0.75rem;
+}
+
+.measurement-buttons {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.rotary-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.rotary-wrapper {
+  position: relative;
+  width: 220px;
+  height: 220px;
+}
+
+.rotary-knob {
+  --rotation: -90deg;
+  position: absolute;
+  inset: 40px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(86, 108, 128, 0.85), rgba(22, 32, 40, 0.95));
+  box-shadow: inset -12px -12px 26px rgba(0, 0, 0, 0.45), inset 6px 6px 18px rgba(255, 255, 255, 0.08);
+  transform: rotate(var(--rotation));
+  transition: transform 0.35s ease;
+}
+
+.rotary-indicator {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  width: 6px;
+  height: 42px;
+  background: #f6c65b;
+  border-radius: 3px;
+  transform: translateX(-50%);
+  box-shadow: 0 0 12px rgba(246, 198, 91, 0.45);
+}
+
+.rotary-center {
+  position: absolute;
+  inset: 50%;
+  width: 46px;
+  height: 46px;
+  margin: -23px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(10, 12, 18, 0.9), rgba(0, 0, 0, 0.95));
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.12);
+}
+
+.rotary-options {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.rotary-option {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: rotate(var(--angle)) translateY(-100px) rotate(calc(-1 * var(--angle)));
+  background: transparent;
+  border: none;
+  color: rgba(225, 238, 255, 0.72);
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  pointer-events: auto;
+  padding: 0.25rem 0.35rem;
+  border-radius: 6px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.rotary-option:hover,
+.rotary-option:focus {
+  outline: none;
+  color: #f6c65b;
+}
+
+.rotary-option.is-active {
+  color: #7df9a9;
+  background: rgba(125, 249, 169, 0.12);
+}
+
+.rotary-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(225, 238, 255, 0.6);
+}
+
+.multimeter-status-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.multimeter-updates {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(225, 238, 255, 0.7);
 }
 
 /* Math zone ------------------------------------------------------------- */

--- a/data/virtual-lab/js/multimeter.js
+++ b/data/virtual-lab/js/multimeter.js
@@ -1,21 +1,97 @@
 import { fetchInputsSnapshot } from './ioCatalog.js';
 
-const MEASUREMENTS = {
-  voltage: { label: 'Tension DC', unit: 'V', range: [3.28, 3.34] },
-  voltageAc: { label: 'Tension AC', unit: 'V RMS', range: [229.2, 231.5] },
-  current: { label: 'Courant', unit: 'mA', range: [12.3, 12.9] },
-  resistance: { label: 'Résistance', unit: 'kΩ', range: [1.48, 1.53] }
+const MEASUREMENT_PROFILES = {
+  voltage: {
+    id: 'voltage',
+    symbol: 'U',
+    label: 'Tension',
+    defaultCalibre: '20V',
+    calibrations: [
+      { id: '200mV', label: '200 mV', max: 0.2, unit: 'mV', displayMultiplier: 1000, decimals: 2, fallbackDisplay: [12, 180] },
+      { id: '2V', label: '2 V', max: 2, unit: 'V', displayMultiplier: 1, decimals: 4, fallbackDisplay: [0.6, 1.8] },
+      { id: '20V', label: '20 V', max: 20, unit: 'V', displayMultiplier: 1, decimals: 3, fallbackDisplay: [2.5, 18] },
+      { id: '200V', label: '200 V', max: 200, unit: 'V', displayMultiplier: 1, decimals: 2, fallbackDisplay: [190, 230] },
+      { id: '1000V', label: '1000 V', max: 1000, unit: 'V', displayMultiplier: 1, decimals: 1, fallbackDisplay: [215, 230] }
+    ]
+  },
+  resistance: {
+    id: 'resistance',
+    symbol: 'Ω',
+    label: 'Résistance',
+    defaultCalibre: '20k',
+    calibrations: [
+      { id: '200', label: '200 Ω', max: 200, unit: 'Ω', displayMultiplier: 1, decimals: 1, fallbackDisplay: [24, 180] },
+      { id: '2k', label: '2 kΩ', max: 2000, unit: 'kΩ', displayMultiplier: 0.001, decimals: 3, fallbackDisplay: [0.65, 1.95] },
+      { id: '20k', label: '20 kΩ', max: 20000, unit: 'kΩ', displayMultiplier: 0.001, decimals: 2, fallbackDisplay: [1.8, 12.5] },
+      { id: '200k', label: '200 kΩ', max: 200000, unit: 'kΩ', displayMultiplier: 0.001, decimals: 1, fallbackDisplay: [15, 120] },
+      { id: '2M', label: '2 MΩ', max: 2000000, unit: 'MΩ', displayMultiplier: 0.000001, decimals: 3, fallbackDisplay: [0.35, 1.25] }
+    ]
+  },
+  current: {
+    id: 'current',
+    symbol: 'I',
+    label: 'Courant',
+    defaultCalibre: '200mA',
+    calibrations: [
+      { id: '200uA', label: '200 µA', max: 0.0002, unit: 'µA', displayMultiplier: 1000000, decimals: 2, fallbackDisplay: [12, 160] },
+      { id: '2mA', label: '2 mA', max: 0.002, unit: 'mA', displayMultiplier: 1000, decimals: 3, fallbackDisplay: [0.85, 1.65] },
+      { id: '20mA', label: '20 mA', max: 0.02, unit: 'mA', displayMultiplier: 1000, decimals: 2, fallbackDisplay: [4, 18] },
+      { id: '200mA', label: '200 mA', max: 0.2, unit: 'mA', displayMultiplier: 1000, decimals: 1, fallbackDisplay: [12, 180] },
+      { id: '10A', label: '10 A', max: 10, unit: 'A', displayMultiplier: 1, decimals: 2, fallbackDisplay: [0.2, 6.5] }
+    ]
+  },
+  frequency: {
+    id: 'frequency',
+    symbol: 'Hz',
+    label: 'Fréquence',
+    defaultCalibre: '20kHz',
+    calibrations: [
+      { id: '200Hz', label: '200 Hz', max: 200, unit: 'Hz', displayMultiplier: 1, decimals: 1, fallbackDisplay: [40, 180] },
+      { id: '2kHz', label: '2 kHz', max: 2000, unit: 'kHz', displayMultiplier: 0.001, decimals: 3, fallbackDisplay: [0.3, 1.5] },
+      { id: '20kHz', label: '20 kHz', max: 20000, unit: 'kHz', displayMultiplier: 0.001, decimals: 2, fallbackDisplay: [3.2, 18.4] },
+      { id: '200kHz', label: '200 kHz', max: 200000, unit: 'kHz', displayMultiplier: 0.001, decimals: 1, fallbackDisplay: [22, 160] }
+    ]
+  },
+  capacitance: {
+    id: 'capacitance',
+    symbol: 'F',
+    label: 'Capacité',
+    defaultCalibre: '200uF',
+    calibrations: [
+      { id: '200nF', label: '200 nF', max: 0.0000002, unit: 'nF', displayMultiplier: 1000000000, decimals: 1, fallbackDisplay: [12, 180] },
+      { id: '2uF', label: '2 µF', max: 0.000002, unit: 'µF', displayMultiplier: 1000000, decimals: 2, fallbackDisplay: [0.18, 1.8] },
+      { id: '200uF', label: '200 µF', max: 0.0002, unit: 'µF', displayMultiplier: 1000000, decimals: 1, fallbackDisplay: [18, 160] },
+      { id: '2mF', label: '2 mF', max: 0.002, unit: 'mF', displayMultiplier: 1000, decimals: 2, fallbackDisplay: [0.4, 1.7] }
+    ]
+  },
+  inductance: {
+    id: 'inductance',
+    symbol: 'H',
+    label: 'Inductance',
+    defaultCalibre: '200mH',
+    calibrations: [
+      { id: '200uH', label: '200 µH', max: 0.0002, unit: 'µH', displayMultiplier: 1000000, decimals: 1, fallbackDisplay: [12, 180] },
+      { id: '2mH', label: '2 mH', max: 0.002, unit: 'mH', displayMultiplier: 1000, decimals: 2, fallbackDisplay: [0.45, 1.6] },
+      { id: '200mH', label: '200 mH', max: 0.2, unit: 'mH', displayMultiplier: 1000, decimals: 1, fallbackDisplay: [12, 160] },
+      { id: '2H', label: '2 H', max: 2, unit: 'H', displayMultiplier: 1, decimals: 3, fallbackDisplay: [0.35, 1.85] }
+    ]
+  }
 };
+
+const MEASUREMENT_ORDER = ['voltage', 'resistance', 'current', 'frequency', 'capacitance', 'inductance'];
 
 function randomInRange([min, max]) {
   return Math.random() * (max - min) + min;
 }
 
-function formatValue(value, digits = 3) {
-  if (value === null || value === undefined) {
+function formatDisplay(value, decimals) {
+  if (value === null || Number.isNaN(value)) {
     return '—';
   }
-  return Number(value).toFixed(digits).replace('.', ',');
+  return new Intl.NumberFormat('fr-FR', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  }).format(value);
 }
 
 function populateSelect(select, options, placeholder) {
@@ -39,9 +115,10 @@ function populateSelect(select, options, placeholder) {
 
 export function mountMultimeter(container, { inputs = [], error = null } = {}) {
   if (!container) return;
+
   container.innerHTML = `
     <div class="device-shell multimeter-shell">
-      <div class="device-header">
+      <div class="multimeter-head">
         <div class="device-branding">
           <span class="device-brand">Keysight</span>
           <span class="device-model" id="multimeter-title">34470A</span>
@@ -52,40 +129,76 @@ export function mountMultimeter(container, { inputs = [], error = null } = {}) {
           <select id="multimeter-input" class="io-select"></select>
         </div>
       </div>
-      <div class="device-status" id="multimeter-status"></div>
-      <div class="multimeter-display" role="img" aria-label="Affichage de mesure">
-        <div class="multimeter-readout" id="multimeter-value">0,000</div>
-        <div class="multimeter-unit" id="multimeter-unit">V</div>
-      </div>
-      <div class="multimeter-controls">
-        <label>
-          Mode
-          <select id="multimeter-mode" class="io-select"></select>
-        </label>
-        <label>
-          Filtre numérique
-          <input type="range" id="multimeter-filter" min="0" max="100" value="40">
-        </label>
-        <label>
-          Barregraph
-          <progress id="multimeter-bar" max="100" value="30" aria-label="Barregraph numérique"></progress>
-        </label>
-        <label>
-          Dernière lecture
-          <span id="multimeter-updated">—</span>
-        </label>
+      <div class="multimeter-body">
+        <div class="multimeter-display" role="img" aria-label="Affichage de mesure">
+          <div class="multimeter-value-line">
+            <span class="multimeter-readout" id="multimeter-value">0,0000</span>
+            <span class="multimeter-symbol" id="multimeter-symbol">U</span>
+          </div>
+          <div class="multimeter-display-footer">
+            <span class="multimeter-unit" id="multimeter-unit">V</span>
+            <span class="multimeter-acdc" id="multimeter-acdc-label">DC</span>
+            <span class="multimeter-hold-indicator" id="multimeter-hold-indicator" hidden>HOLD</span>
+          </div>
+          <progress id="multimeter-bar" max="100" value="0" aria-label="Barregraph numérique"></progress>
+        </div>
+        <div class="multimeter-sidepanel">
+          <div class="multimeter-actions">
+            <button type="button" class="meter-button meter-button--power is-active" data-action="power" aria-pressed="true">Power</button>
+            <button type="button" class="meter-button" data-action="acdc" aria-pressed="false">AC/DC</button>
+            <div class="measurement-buttons" role="group" aria-label="Type de mesure"></div>
+            <button type="button" class="meter-button" data-action="hold" aria-pressed="false">HOLD</button>
+          </div>
+          <div class="rotary-section">
+            <div class="rotary-wrapper">
+              <div class="rotary-knob" id="multimeter-calibre-knob">
+                <div class="rotary-indicator"></div>
+                <div class="rotary-center"></div>
+              </div>
+              <div class="rotary-options" id="multimeter-calibre-options" role="list"></div>
+            </div>
+            <span class="rotary-label">Calibre</span>
+          </div>
+          <div class="multimeter-status-panel">
+            <div class="device-status" id="multimeter-status"></div>
+            <div class="multimeter-updates">
+              <span>Dernière lecture</span>
+              <span id="multimeter-updated">—</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   `;
 
-  const modeSelect = container.querySelector('#multimeter-mode');
+  const defaultMode = MEASUREMENT_ORDER[0];
+  const state = {
+    powered: true,
+    acMode: 'dc',
+    hold: false,
+    measurementMode: defaultMode,
+    calibreId: MEASUREMENT_PROFILES[defaultMode].defaultCalibre,
+    timer: null,
+    previousValue: null,
+    lastBaseValue: null,
+    heldValue: null
+  };
+
   const valueDisplay = container.querySelector('#multimeter-value');
+  const symbolDisplay = container.querySelector('#multimeter-symbol');
   const unitDisplay = container.querySelector('#multimeter-unit');
-  const filterRange = container.querySelector('#multimeter-filter');
+  const acdcLabel = container.querySelector('#multimeter-acdc-label');
+  const holdIndicator = container.querySelector('#multimeter-hold-indicator');
   const bar = container.querySelector('#multimeter-bar');
   const updatedLabel = container.querySelector('#multimeter-updated');
   const inputSelect = container.querySelector('#multimeter-input');
   const statusLabel = container.querySelector('#multimeter-status');
+  const powerButton = container.querySelector('[data-action="power"]');
+  const acdcButton = container.querySelector('[data-action="acdc"]');
+  const holdButton = container.querySelector('[data-action="hold"]');
+  const measurementContainer = container.querySelector('.measurement-buttons');
+  const knob = container.querySelector('#multimeter-calibre-knob');
+  const knobOptions = container.querySelector('#multimeter-calibre-options');
 
   populateSelect(inputSelect, inputs, 'Aucune entrée active');
   const ioMap = new Map(inputs.map((item) => [item.name, item]));
@@ -98,72 +211,201 @@ export function mountMultimeter(container, { inputs = [], error = null } = {}) {
     statusLabel.textContent = 'Activez une entrée dans la configuration.';
   }
 
-  Object.entries(MEASUREMENTS).forEach(([key, { label }]) => {
-    const option = document.createElement('option');
-    option.value = key;
-    option.textContent = label;
-    modeSelect.appendChild(option);
-  });
+  const getCurrentProfile = () => MEASUREMENT_PROFILES[state.measurementMode] || MEASUREMENT_PROFILES[defaultMode];
 
-  const state = {
-    previousValue: null,
-    timer: null
+  const getCurrentCalibre = () => {
+    const profile = getCurrentProfile();
+    return profile.calibrations.find((cal) => cal.id === state.calibreId) || profile.calibrations[0];
   };
 
-  const getSmoothedValue = (raw, smoothing) => {
-    if (raw === null) {
+  const updateSymbolAndUnit = () => {
+    const profile = getCurrentProfile();
+    const calibre = getCurrentCalibre();
+    symbolDisplay.textContent = profile.symbol;
+    unitDisplay.textContent = calibre.unit;
+  };
+
+  const updateCalibrationButtons = () => {
+    knobOptions.querySelectorAll('[data-calibre]').forEach((btn) => {
+      const isActive = btn.dataset.calibre === state.calibreId;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  };
+
+  const updateKnobRotation = () => {
+    const profile = getCurrentProfile();
+    const index = profile.calibrations.findIndex((cal) => cal.id === state.calibreId);
+    if (index === -1) {
+      knob.style.setProperty('--rotation', '-90deg');
+      return;
+    }
+    const step = 360 / profile.calibrations.length;
+    const angle = -90 + index * step;
+    knob.style.setProperty('--rotation', `${angle}deg`);
+  };
+
+  const renderCalibrations = (profile) => {
+    knobOptions.innerHTML = '';
+    const step = 360 / profile.calibrations.length;
+    profile.calibrations.forEach((cal, index) => {
+      const angle = -90 + index * step;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'rotary-option';
+      button.dataset.calibre = cal.id;
+      button.style.setProperty('--angle', `${angle}deg`);
+      button.textContent = cal.label;
+      button.setAttribute('role', 'listitem');
+      button.setAttribute('aria-label', `Calibre ${cal.label}`);
+      button.setAttribute('aria-pressed', cal.id === state.calibreId ? 'true' : 'false');
+      button.addEventListener('click', () => {
+        if (state.calibreId === cal.id) {
+          return;
+        }
+        state.calibreId = cal.id;
+        state.previousValue = null;
+        state.lastBaseValue = null;
+        updateKnobRotation();
+        updateCalibrationButtons();
+        refreshMeasurement();
+      });
+      knobOptions.appendChild(button);
+    });
+    updateCalibrationButtons();
+    updateKnobRotation();
+  };
+
+  MEASUREMENT_ORDER.forEach((mode) => {
+    const profile = MEASUREMENT_PROFILES[mode];
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'meter-button meter-button--measurement';
+    button.dataset.measurement = mode;
+    button.textContent = profile.symbol;
+    button.setAttribute('aria-label', `${profile.label} (${profile.symbol})`);
+    const isActive = state.measurementMode === mode;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    measurementContainer.appendChild(button);
+  });
+
+  const measurementButtons = Array.from(measurementContainer.querySelectorAll('[data-measurement]'));
+
+  const getSmoothedValue = (raw) => {
+    if (raw === null || Number.isNaN(raw)) {
+      state.previousValue = null;
       return null;
     }
     if (state.previousValue === null || Number.isNaN(state.previousValue)) {
       state.previousValue = raw;
       return raw;
     }
-    const alpha = Math.max(0.02, 1 - smoothing);
+    const alpha = 0.18;
     state.previousValue = state.previousValue + (raw - state.previousValue) * alpha;
     return state.previousValue;
   };
 
-  const updateDisplay = (value, metadata) => {
-    const { unit, range } = metadata;
-    valueDisplay.textContent = formatValue(value);
-    unitDisplay.textContent = unit;
-    if (value === null || !range || range[0] === range[1]) {
-      bar.value = 0;
-    } else {
-      const percent = ((value - range[0]) / (range[1] - range[0])) * 100;
-      bar.value = Math.min(100, Math.max(0, percent));
+  const randomFallbackBase = (calibre) => {
+    if (!calibre || !calibre.fallbackDisplay) {
+      return null;
     }
+    const displayValue = randomInRange(calibre.fallbackDisplay);
+    return displayValue / calibre.displayMultiplier;
   };
 
-  const refreshMeasurement = async () => {
-    const measurement = MEASUREMENTS[modeSelect.value] || MEASUREMENTS.voltage;
-    const selectedName = inputSelect.value;
-    const smoothing = parseInt(filterRange.value, 10) / 100;
-    if (!selectedName) {
-      state.previousValue = null;
-      updateDisplay(null, { unit: measurement.unit, range: measurement.range });
-      updatedLabel.textContent = '—';
+  const applyAcMode = (value) => {
+    if (value === null || Number.isNaN(value)) {
+      return null;
+    }
+    if (state.acMode === 'ac') {
+      return Math.abs(value);
+    }
+    return value;
+  };
+
+  const updateDisplay = (baseValue) => {
+    const profile = getCurrentProfile();
+    const calibre = getCurrentCalibre();
+    if (baseValue === null || Number.isNaN(baseValue)) {
+      valueDisplay.textContent = '—';
+      unitDisplay.textContent = calibre.unit;
+      symbolDisplay.textContent = profile.symbol;
+      bar.value = 0;
       return;
     }
+    if (Math.abs(baseValue) > calibre.max) {
+      valueDisplay.textContent = 'OL';
+      unitDisplay.textContent = calibre.unit;
+      symbolDisplay.textContent = profile.symbol;
+      bar.value = 100;
+      return;
+    }
+    const displayValue = baseValue * calibre.displayMultiplier;
+    valueDisplay.textContent = formatDisplay(displayValue, calibre.decimals);
+    unitDisplay.textContent = calibre.unit;
+    symbolDisplay.textContent = profile.symbol;
+    const rangeDisplayMax = calibre.max * calibre.displayMultiplier;
+    const percent = rangeDisplayMax === 0 ? 0 : Math.min(100, Math.abs(displayValue) / rangeDisplayMax * 100);
+    bar.value = percent;
+  };
+
+  const displayOff = () => {
+    valueDisplay.textContent = '----';
+    unitDisplay.textContent = '';
+    symbolDisplay.textContent = '';
+    acdcLabel.textContent = '';
+    bar.value = 0;
+  };
+
+  const refreshMeasurement = async ({ force = false } = {}) => {
+    if (!state.powered) {
+      return;
+    }
+    const profile = getCurrentProfile();
+    const calibre = getCurrentCalibre();
+    acdcLabel.textContent = state.acMode === 'ac' ? 'AC' : 'DC';
+    if (state.hold && !force) {
+      const held = state.heldValue !== null ? state.heldValue : state.lastBaseValue;
+      if (held !== null) {
+        updateDisplay(held);
+        statusLabel.textContent = 'Maintien de la lecture (HOLD)';
+      } else {
+        updateDisplay(null);
+      }
+      return;
+    }
+
+    const selectedName = inputSelect.value;
+    if (!selectedName) {
+      state.lastBaseValue = null;
+      updateDisplay(null);
+      updatedLabel.textContent = '—';
+      statusLabel.textContent = 'Aucune entrée sélectionnée';
+      return;
+    }
+
     try {
       const snapshot = await fetchInputsSnapshot();
-      const raw = Object.prototype.hasOwnProperty.call(snapshot, selectedName)
-        ? snapshot[selectedName]
-        : null;
-      const value = raw !== null ? getSmoothedValue(raw, smoothing) : null;
-      const ioInfo = ioMap.get(selectedName);
-      const unit = (ioInfo && ioInfo.unit) || measurement.unit;
-      updateDisplay(value, { unit, range: measurement.range });
+      const rawValue = Object.prototype.hasOwnProperty.call(snapshot, selectedName)
+        ? Number(snapshot[selectedName])
+        : NaN;
+      const processed = applyAcMode(Number.isFinite(rawValue) ? rawValue : NaN);
+      const smoothed = getSmoothedValue(processed);
+      state.lastBaseValue = smoothed;
+      updateDisplay(smoothed);
       const now = new Date();
       updatedLabel.textContent = now.toLocaleTimeString('fr-FR', { hour12: false });
-      statusLabel.textContent = raw === null
-        ? `Lecture indisponible pour ${selectedName}`
-        : `Lecture en cours sur ${selectedName}`;
+      const ioInfo = ioMap.get(selectedName);
+      const unit = ioInfo && ioInfo.unit ? ` (${ioInfo.unit})` : '';
+      statusLabel.textContent = `Lecture ${state.acMode === 'ac' ? 'AC' : 'DC'} sur ${selectedName}${unit}`;
     } catch (err) {
-      statusLabel.textContent = 'Erreur lors de la lecture des entrées';
-      const fallbackValue = getSmoothedValue(randomInRange(measurement.range), smoothing);
-      updateDisplay(fallbackValue, { unit: measurement.unit, range: measurement.range });
+      const fallbackBase = randomFallbackBase(calibre);
+      const smoothed = getSmoothedValue(fallbackBase);
+      state.lastBaseValue = smoothed;
+      updateDisplay(smoothed);
       updatedLabel.textContent = '—';
+      statusLabel.textContent = 'Lecture simulée (pas de données disponibles)';
     }
   };
 
@@ -171,21 +413,104 @@ export function mountMultimeter(container, { inputs = [], error = null } = {}) {
     if (state.timer) {
       clearInterval(state.timer);
     }
+    if (!state.powered) {
+      return;
+    }
     state.timer = setInterval(refreshMeasurement, 1200);
   };
 
-  modeSelect.addEventListener('change', () => {
+  measurementButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.measurement;
+      if (state.measurementMode === mode) {
+        return;
+      }
+      state.measurementMode = mode;
+      const profile = getCurrentProfile();
+      state.calibreId = profile.defaultCalibre || profile.calibrations[0].id;
+      state.previousValue = null;
+      state.lastBaseValue = null;
+      state.heldValue = null;
+      state.hold = false;
+      holdIndicator.hidden = true;
+      holdButton.classList.remove('is-active');
+      holdButton.setAttribute('aria-pressed', 'false');
+      measurementButtons.forEach((btn) => {
+        const isActive = btn.dataset.measurement === mode;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+      updateSymbolAndUnit();
+      renderCalibrations(profile);
+      refreshMeasurement();
+    });
+  });
+
+  powerButton.addEventListener('click', () => {
+    state.powered = !state.powered;
+    powerButton.classList.toggle('is-active', state.powered);
+    powerButton.setAttribute('aria-pressed', state.powered ? 'true' : 'false');
+    if (state.powered) {
+      holdIndicator.hidden = !state.hold;
+      statusLabel.textContent = 'Alimentation activée';
+      scheduleRefresh();
+      refreshMeasurement();
+    } else {
+      if (state.timer) {
+        clearInterval(state.timer);
+        state.timer = null;
+      }
+      updatedLabel.textContent = '—';
+      statusLabel.textContent = 'Appareil hors tension';
+      holdIndicator.hidden = true;
+      displayOff();
+    }
+  });
+
+  acdcButton.addEventListener('click', () => {
+    state.acMode = state.acMode === 'dc' ? 'ac' : 'dc';
+    const isAc = state.acMode === 'ac';
+    acdcButton.classList.toggle('is-active', isAc);
+    acdcButton.setAttribute('aria-pressed', isAc ? 'true' : 'false');
     state.previousValue = null;
     refreshMeasurement();
   });
 
-  filterRange.addEventListener('input', () => {
-    state.previousValue = null;
-    refreshMeasurement();
+  holdButton.addEventListener('click', async () => {
+    const wantHold = !state.hold;
+    state.hold = wantHold;
+    holdButton.classList.toggle('is-active', wantHold);
+    holdButton.setAttribute('aria-pressed', wantHold ? 'true' : 'false');
+    if (wantHold) {
+      if (state.lastBaseValue === null) {
+        await refreshMeasurement({ force: true });
+      }
+      state.heldValue = state.lastBaseValue;
+      holdIndicator.hidden = false;
+      if (state.heldValue !== null) {
+        updateDisplay(state.heldValue);
+        statusLabel.textContent = 'Maintien de la lecture (HOLD)';
+      } else {
+        updateDisplay(null);
+        statusLabel.textContent = 'Maintien actif - en attente de mesure';
+      }
+    } else {
+      state.heldValue = null;
+      holdIndicator.hidden = true;
+      refreshMeasurement();
+    }
   });
 
   inputSelect.addEventListener('change', () => {
     state.previousValue = null;
+    state.lastBaseValue = null;
+    state.heldValue = null;
+    if (state.hold) {
+      state.hold = false;
+      holdButton.classList.remove('is-active');
+      holdButton.setAttribute('aria-pressed', 'false');
+      holdIndicator.hidden = true;
+    }
     refreshMeasurement();
   });
 
@@ -195,7 +520,8 @@ export function mountMultimeter(container, { inputs = [], error = null } = {}) {
     }
   });
 
-  modeSelect.value = 'voltage';
+  updateSymbolAndUnit();
+  renderCalibrations(getCurrentProfile());
   refreshMeasurement();
   scheduleRefresh();
 }


### PR DESCRIPTION
## Summary
- refonte complète de l’interface du multimètre virtuel avec affichage grand format, indicateurs AC/DC et HOLD
- ajout des boutons Power, AC/DC, HOLD et des sélecteurs U/Ω/I/Hz/F/H associés à des calibres sur un bouton rotatif
- adaptation de la logique de mesure : gestion des calibres, formatage décimal, surcharge, maintien et bascule AC/DC

## Testing
- not run (non disponible)


------
https://chatgpt.com/codex/tasks/task_e_68cc465ff4e4832ea9b98c9bac776ef4