### PR TITLE
Move virtual multimeter configuration to dedicated page

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -62,20 +62,16 @@
     .modal-info h3 { margin: 0 0 0.35em; font-size: 1em; }
     .modal-info ul { margin: 0.4em 0 0 1.2em; padding: 0; }
     .modal-info li { margin-bottom: 0.3em; }
-    .meter-list .io-card { gap: 0.8em; }
-    .meter-fields { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 0.6em; }
-    .meter-field { display: flex; flex-direction: column; gap: 0.25em; font-size: 0.9em; }
-    .meter-field label { font-weight: 600; color: #333; }
-    .meter-field input[type="text"],
-    .meter-field input[type="number"],
-    .meter-field select { width: 100%; box-sizing: border-box; }
-    .meter-field input[type="number"] { max-width: 100%; }
-    .meter-card .io-actions { margin-top: 0.5em; }
   </style>
   <script src="auth.js"></script>
 </head>
 <body>
 <h1>Configuration MiniLabBox</h1>
+
+<p class="hint">
+  Les réglages du multimètre virtuel et des autres instruments sont désormais disponibles sur la page
+  <a href="virtual-lab/settings.html">Réglages Virtual Lab</a>.
+</p>
 
 <form id="configForm" onsubmit="return false;">
   <fieldset>
@@ -128,16 +124,6 @@
       <span class="counter" id="outputsCounter">0 / 2</span>
     </div>
     <div id="outputsList" class="io-list"></div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Multimètre virtuel</legend>
-    <p class="hint">Associez chaque canal du multimètre à une entrée et ajustez l'échelle, le décalage ainsi que la plage et la résolution binaire.</p>
-    <div class="io-header">
-      <button type="button" id="addMeterBtn">Ajouter un canal</button>
-      <span class="counter" id="meterCounter">0 / 6</span>
-    </div>
-    <div id="meterList" class="io-list meter-list"></div>
   </fieldset>
 
   <fieldset>
@@ -207,9 +193,6 @@
 <script>
 const MAX_INPUTS = 4;
 const MAX_OUTPUTS = 2;
-const MAX_METER_CHANNELS = 6;
-const MIN_METER_BITS = 1;
-const MAX_METER_BITS = 32;
 const ANALOG_PINS = ['A0'];
 const DIGITAL_PINS = ['D0','D1','D2','D3','D4','D5','D6','D7','D8'];
 const ANALOG_TYPES = new Set(['adc','div','zmpt','zmct']);
@@ -422,7 +405,6 @@ function getIoExplanation(kind, data, fallbackName, indexHint) {
 
 let inputs = [];
 let outputs = [];
-let meterChannels = [];
 const moduleState = {
   ads1115: false,
   pwm010: false,
@@ -838,85 +820,6 @@ function updateIoCounters() {
   if (outCounter) outCounter.textContent = `${outputs.length} / ${MAX_OUTPUTS}`;
 }
 
-function updateMeterCounter() {
-  const counter = document.getElementById('meterCounter');
-  if (counter) counter.textContent = `${meterChannels.length} / ${MAX_METER_CHANNELS}`;
-}
-
-function clampMeterBits(value) {
-  const numeric = Number.isFinite(value) ? value : Number(value);
-  if (!Number.isFinite(numeric)) {
-    return 10;
-  }
-  const rounded = Math.round(numeric);
-  if (rounded < MIN_METER_BITS) return MIN_METER_BITS;
-  if (rounded > MAX_METER_BITS) return MAX_METER_BITS;
-  return rounded;
-}
-
-function defaultMeterChannel(index) {
-  const baseIndex = Number.isFinite(index) ? index : meterChannels.length;
-  const suffix = baseIndex + 1;
-  const defaultId = `meter${suffix}`;
-  const activeInputs = inputs.filter(item => item && item.active !== false);
-  const preferredInput = activeInputs.length ? activeInputs[0] : (inputs.length ? inputs[0] : null);
-  return {
-    id: defaultId,
-    name: defaultId,
-    label: `Canal ${suffix}`,
-    input: preferredInput ? preferredInput.name : '',
-    unit: preferredInput && preferredInput.unit ? preferredInput.unit : '',
-    symbol: '',
-    enabled: true,
-    scale: 1,
-    offset: 0,
-    rangeMin: null,
-    rangeMax: null,
-    bits: 10
-  };
-}
-
-function normaliseMeterChannelConfig(data, index) {
-  const fallback = defaultMeterChannel(Number.isFinite(index) ? index : 0);
-  if (!data || typeof data !== 'object') {
-    return fallback;
-  }
-  const idValue = typeof data.id === 'string' && data.id.trim().length
-    ? data.id.trim()
-    : typeof data.name === 'string' && data.name.trim().length
-      ? data.name.trim()
-      : fallback.id;
-  const nameValue = typeof data.name === 'string' && data.name.trim().length
-    ? data.name.trim()
-    : idValue;
-  const labelValue = typeof data.label === 'string' && data.label.trim().length
-    ? data.label.trim()
-    : nameValue;
-  const inputValue = typeof data.input === 'string' ? data.input.trim() : fallback.input;
-  const symbolValue = typeof data.symbol === 'string' ? data.symbol.trim() : '';
-  const unitValue = typeof data.unit === 'string' ? data.unit.trim() : '';
-  const scaleValue = toNumber(data.scale, 1);
-  const offsetValue = toNumber(data.offset, 0);
-  const rangeMinValue = toNumber(data.rangeMin, null);
-  const rangeMaxValue = toNumber(data.rangeMax, null);
-  const bitsValue = clampMeterBits(toNumber(data.bits, 10));
-  const enabledValue = data.enabled === false ? false : true;
-  return {
-    id: idValue,
-    name: nameValue,
-    label: labelValue,
-    input: inputValue,
-    symbol: symbolValue,
-    unit: unitValue,
-    enabled: enabledValue,
-    scale: Number.isFinite(scaleValue) ? scaleValue : 1,
-    offset: Number.isFinite(offsetValue) ? offsetValue : 0,
-    rangeMin: Number.isFinite(rangeMinValue) ? rangeMinValue : null,
-    rangeMax: Number.isFinite(rangeMaxValue) ? rangeMaxValue : null,
-    bits: bitsValue
-  };
-}
-
 function describeInput(item, index) {
   const fallbackName = item && item.name && item.name.trim()
     ? item.name.trim()
@@ -969,277 +872,6 @@ function describeOutput(item, index) {
   return details;
 }
 
-function renderMeterList() {
-  const listEl = document.getElementById('meterList');
-  if (!listEl) return;
-  listEl.innerHTML = '';
-  if (!meterChannels.length) {
-    const empty = document.createElement('div');
-    empty.className = 'io-empty';
-    empty.textContent = 'Aucun canal configuré pour le multimètre.';
-    listEl.appendChild(empty);
-    updateMeterCounter();
-    return;
-  }
-  meterChannels.forEach((channel, idx) => {
-    const card = document.createElement('div');
-    card.className = 'io-card meter-card';
-
-    const header = document.createElement('div');
-    header.className = 'io-card-header';
-    const title = document.createElement('h3');
-    const computeTitle = () => {
-      if (channel.label && channel.label.trim().length) {
-        return channel.label.trim();
-      }
-      if (channel.name && channel.name.trim().length) {
-        return channel.name.trim();
-      }
-      return `Canal ${idx + 1}`;
-    };
-    title.textContent = computeTitle();
-    header.appendChild(title);
-
-    const controls = document.createElement('div');
-    controls.style.display = 'flex';
-    controls.style.flexDirection = 'column';
-    controls.style.alignItems = 'flex-end';
-    controls.style.gap = '0.35em';
-
-    const toggleLabel = document.createElement('label');
-    toggleLabel.className = 'toggle';
-    const toggle = document.createElement('input');
-    toggle.type = 'checkbox';
-    toggle.checked = channel.enabled !== false;
-    toggle.addEventListener('change', () => {
-      channel.enabled = toggle.checked;
-    });
-    toggleLabel.appendChild(toggle);
-    toggleLabel.appendChild(document.createTextNode(' Actif'));
-    controls.appendChild(toggleLabel);
-
-    const status = document.createElement('span');
-    const updateStatus = () => {
-      const hasInput = channel.input && channel.input.trim().length;
-      status.className = `io-status ${hasInput ? 'synced' : 'pending'}`;
-      status.textContent = hasInput ? `Source : ${channel.input}` : 'Entrée à sélectionner';
-    };
-    updateStatus();
-    controls.appendChild(status);
-
-    header.appendChild(controls);
-    card.appendChild(header);
-
-    const fields = document.createElement('div');
-    fields.className = 'meter-fields';
-
-    const addField = (labelText, controlFactory) => {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'meter-field';
-      const label = document.createElement('label');
-      label.textContent = labelText;
-      wrapper.appendChild(label);
-      const control = controlFactory();
-      wrapper.appendChild(control);
-      fields.appendChild(wrapper);
-      return control;
-    };
-
-    addField('Identifiant JSON', () => {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = channel.id || '';
-      input.placeholder = `meter${idx + 1}`;
-      input.oninput = (ev) => {
-        const value = ev.target.value.trim();
-        channel.id = value;
-        channel.name = value || `meter${idx + 1}`;
-        if (!channel.label || !channel.label.trim().length) {
-          title.textContent = computeTitle();
-        }
-      };
-      return input;
-    });
-
-    addField('Libellé (affichage)', () => {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = channel.label || '';
-      input.placeholder = `Canal ${idx + 1}`;
-      input.oninput = (ev) => {
-        channel.label = ev.target.value;
-        title.textContent = computeTitle();
-      };
-      return input;
-    });
-
-    let unitInputRef = null;
-
-    addField('Entrée associée', () => {
-      const select = document.createElement('select');
-      const activeInputs = inputs.filter(item => item && item.active !== false);
-      if (!activeInputs.length) {
-        const opt = document.createElement('option');
-        opt.value = '';
-        opt.textContent = 'Aucune entrée disponible';
-        select.appendChild(opt);
-        select.disabled = true;
-      } else {
-        const placeholder = document.createElement('option');
-        placeholder.value = '';
-        placeholder.textContent = 'Choisir…';
-        select.appendChild(placeholder);
-        activeInputs.forEach(info => {
-          const opt = document.createElement('option');
-          opt.value = info.name;
-          opt.textContent = info.name;
-          select.appendChild(opt);
-        });
-        if (channel.input && activeInputs.some(info => info.name === channel.input)) {
-          select.value = channel.input;
-        } else {
-          select.value = '';
-        }
-      }
-      select.addEventListener('change', (ev) => {
-        channel.input = ev.target.value;
-        updateStatus();
-        const matching = inputs.find(item => item && item.name === channel.input);
-        if (matching && matching.unit && (!channel.unit || !channel.unit.trim().length)) {
-          channel.unit = matching.unit;
-          if (unitInputRef) {
-            unitInputRef.value = channel.unit;
-          }
-        }
-      });
-      return select;
-    });
-
-    addField('Symbole', () => {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = channel.symbol || '';
-      input.placeholder = 'U, I, R…';
-      input.oninput = (ev) => {
-        channel.symbol = ev.target.value;
-      };
-      return input;
-    });
-
-    unitInputRef = addField('Unité', () => {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = channel.unit || '';
-      input.placeholder = 'V, A, Ω…';
-      input.oninput = (ev) => {
-        channel.unit = ev.target.value;
-      };
-      return input;
-    });
-
-    addField('Échelle', () => {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.step = 'any';
-      input.value = channel.scale != null ? channel.scale : 1;
-      input.oninput = (ev) => {
-        const value = parseFloat(ev.target.value);
-        channel.scale = Number.isFinite(value) ? value : 1;
-      };
-      return input;
-    });
-
-    addField('Décalage', () => {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.step = 'any';
-      input.value = channel.offset != null ? channel.offset : 0;
-      input.oninput = (ev) => {
-        const value = parseFloat(ev.target.value);
-        channel.offset = Number.isFinite(value) ? value : 0;
-      };
-      return input;
-    });
-
-    addField('Plage min.', () => {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.step = 'any';
-      input.value = channel.rangeMin != null ? channel.rangeMin : '';
-      input.oninput = (ev) => {
-        const value = ev.target.value.trim();
-        if (value.length === 0) {
-          channel.rangeMin = null;
-        } else {
-          const num = parseFloat(value);
-          channel.rangeMin = Number.isFinite(num) ? num : null;
-        }
-      };
-      return input;
-    });
-
-    addField('Plage max.', () => {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.step = 'any';
-      input.value = channel.rangeMax != null ? channel.rangeMax : '';
-      input.oninput = (ev) => {
-        const value = ev.target.value.trim();
-        if (value.length === 0) {
-          channel.rangeMax = null;
-        } else {
-          const num = parseFloat(value);
-          channel.rangeMax = Number.isFinite(num) ? num : null;
-        }
-      };
-      return input;
-    });
-
-    addField('Résolution (bits)', () => {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.min = `${MIN_METER_BITS}`;
-      input.max = `${MAX_METER_BITS}`;
-      input.step = '1';
-      input.value = channel.bits != null ? channel.bits : 10;
-      input.addEventListener('change', (ev) => {
-        const value = parseFloat(ev.target.value);
-        channel.bits = clampMeterBits(value);
-        input.value = channel.bits;
-      });
-      return input;
-    });
-
-    card.appendChild(fields);
-
-    const actions = document.createElement('div');
-    actions.className = 'io-actions';
-    const removeBtn = document.createElement('button');
-    removeBtn.type = 'button';
-    removeBtn.className = 'danger';
-    removeBtn.textContent = 'Supprimer';
-    removeBtn.addEventListener('click', () => {
-      meterChannels.splice(idx, 1);
-      renderMeterList();
-    });
-    actions.appendChild(removeBtn);
-    card.appendChild(actions);
-
-    listEl.appendChild(card);
-  });
-  updateMeterCounter();
-}
-
-function addMeterChannel() {
-  if (meterChannels.length >= MAX_METER_CHANNELS) {
-    alert(`Nombre maximum de canaux atteint (${MAX_METER_CHANNELS}).`);
-    return;
-  }
-  const channel = defaultMeterChannel(meterChannels.length);
-  meterChannels.push(channel);
-  renderMeterList();
-}
-
 function renderIoList(kind) {
   const listEl = document.getElementById(kind === 'input' ? 'inputsList' : 'outputsList');
   if (!listEl) return;
@@ -1251,9 +883,6 @@ function renderIoList(kind) {
     empty.textContent = kind === 'input' ? 'Aucune entrée configurée.' : 'Aucune sortie configurée.';
     listEl.appendChild(empty);
     updateIoCounters();
-    if (kind === 'input') {
-      renderMeterList();
-    }
     return;
   }
   source.forEach((item, idx) => {
@@ -1342,9 +971,6 @@ function renderIoList(kind) {
     listEl.appendChild(card);
   });
   updateIoCounters();
-  if (kind === 'input') {
-    renderMeterList();
-  }
 }
 
 function openIoModal(kind, index) {
@@ -1751,15 +1377,6 @@ async function loadConfig() {
     ensureTypeAvailability('output');
     resetSnapshotsFromConfig('input', inputs);
     resetSnapshotsFromConfig('output', outputs);
-    if (cfg.virtualMultimeter && Array.isArray(cfg.virtualMultimeter.channels)) {
-      meterChannels = cfg.virtualMultimeter.channels
-        .slice(0, MAX_METER_CHANNELS)
-        .map((entry, index) => normaliseMeterChannelConfig(entry, index));
-    } else {
-      meterChannels = [];
-    }
-    updateMeterCounter();
-    renderMeterList();
     renderIoList('input');
     renderIoList('output');
     logIoStep('Configuration appliquée', { inputs: inputs.length, outputs: outputs.length });
@@ -1841,36 +1458,6 @@ async function saveConfig() {
     return obj;
   });
   cfg.outputCount = cfg.outputs.length;
-  const meterList = [];
-  meterChannels.slice(0, MAX_METER_CHANNELS).forEach((channel, idx) => {
-    const trimmedId = channel.id && channel.id.trim().length ? channel.id.trim() : `meter${idx + 1}`;
-    const trimmedName = channel.name && channel.name.trim().length ? channel.name.trim() : trimmedId;
-    const trimmedLabel = channel.label && channel.label.trim().length ? channel.label.trim() : trimmedName;
-    const inputName = channel.input && typeof channel.input === 'string' ? channel.input.trim() : '';
-    const symbol = channel.symbol && typeof channel.symbol === 'string' ? channel.symbol.trim() : '';
-    const unit = channel.unit && typeof channel.unit === 'string' ? channel.unit.trim() : '';
-    const scaleValue = toNumber(channel.scale, 1);
-    const offsetValue = toNumber(channel.offset, 0);
-    const rangeMinValue = toNumber(channel.rangeMin, null);
-    const rangeMaxValue = toNumber(channel.rangeMax, null);
-    const bitsValue = clampMeterBits(toNumber(channel.bits, 10));
-    const entry = {
-      id: trimmedId,
-      name: trimmedName,
-      label: trimmedLabel,
-      input: inputName,
-      symbol,
-      unit,
-      enabled: channel.enabled !== false,
-      scale: Number.isFinite(scaleValue) ? scaleValue : 1,
-      offset: Number.isFinite(offsetValue) ? offsetValue : 0,
-      rangeMin: Number.isFinite(rangeMinValue) ? rangeMinValue : null,
-      rangeMax: Number.isFinite(rangeMaxValue) ? rangeMaxValue : null,
-      bits: bitsValue
-    };
-    meterList.push(entry);
-  });
-  cfg.virtualMultimeter = { channelCount: meterList.length, channels: meterList };
   cfg.peers = [];
   knownPeers.forEach((pin, nodeId) => {
     if (!nodeId) return;
@@ -1880,7 +1467,6 @@ async function saveConfig() {
   logIoStep('Configuration assemblée avant envoi', {
     inputs: cfg.inputs.length,
     outputs: cfg.outputs.length,
-    meters: cfg.virtualMultimeter.channelCount,
     peers: cfg.peerCount
   });
 
@@ -2075,10 +1661,6 @@ window.addEventListener('DOMContentLoaded', () => {
   const addOutputBtn = document.getElementById('addOutputBtn');
   if (addOutputBtn) {
     addOutputBtn.addEventListener('click', addOutput);
-  }
-  const addMeterBtn = document.getElementById('addMeterBtn');
-  if (addMeterBtn) {
-    addMeterBtn.addEventListener('click', addMeterChannel);
   }
   ['modAds','modPwm','modDac','modZmpt','modZmct','modDiv'].forEach(id => {
     const checkbox = document.getElementById(id);

--- a/data/index.html
+++ b/data/index.html
@@ -64,6 +64,9 @@
       Accéder au Virtual Lab professionnel
     </a>
     <p>Un environnement immersif regroupant oscilloscope Tektronix, multimètre de laboratoire et générateur de fonctions.</p>
+    <p>
+      <a href="virtual-lab/settings.html">Configurer les appareils virtuels</a>
+    </p>
   </div>
 </div>
 
@@ -89,7 +92,8 @@
   <a href="private/io-exemples.html">Bibliothèque d'exemples IO</a> |
   <a href="logs.html">Logs système</a> |
   <a href="editor.html">Éditeur de fichiers</a> |
-  <a href="virtual-lab/index.html">Virtual Lab</a>
+  <a href="virtual-lab/index.html">Virtual Lab</a> |
+  <a href="virtual-lab/settings.html">Réglages Virtual Lab</a>
 </p>
 
 <h2>Fichiers HTML privés</h2>

--- a/data/virtual-lab/index.html
+++ b/data/virtual-lab/index.html
@@ -22,6 +22,12 @@
     </section>
   </div>
 
+  <div style="text-align:center; margin: 1.5em 0;">
+    <a href="settings.html" style="display:inline-flex; align-items:center; gap:0.4em; padding:0.6em 1.2em; border-radius:999px; background:#0a6dd8; color:#fff; text-decoration:none; font-weight:600; box-shadow:0 12px 28px rgba(10,109,216,0.18);">
+      ⚙️ Configurer les appareils virtuels
+    </a>
+  </div>
+
   <noscript>
     <div class="noscript">Activez JavaScript pour accéder au laboratoire virtuel.</div>
   </noscript>

--- a/data/virtual-lab/js/settings.js
+++ b/data/virtual-lab/js/settings.js
@@ -1,0 +1,458 @@
+const MAX_METER_CHANNELS = 6;
+
+const state = {
+  channels: [],
+  inputs: [],
+};
+
+function normaliseString(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+function normaliseNumber(value, fallback = null) {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  const num = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return num;
+}
+
+function clampBits(value) {
+  let bits = normaliseNumber(value, 10);
+  if (!Number.isFinite(bits)) {
+    bits = 10;
+  }
+  bits = Math.round(bits);
+  if (bits < 1) bits = 1;
+  if (bits > 32) bits = 32;
+  return bits;
+}
+
+function normaliseChannel(entry, index) {
+  const id = normaliseString(entry && entry.id) || `meter${index + 1}`;
+  const name = normaliseString(entry && entry.name) || id;
+  const label = normaliseString(entry && entry.label) || name;
+  const input = normaliseString(entry && entry.input);
+  const unit = normaliseString(entry && entry.unit);
+  const symbol = normaliseString(entry && entry.symbol);
+  const enabled = entry && entry.enabled === false ? false : true;
+  const scale = normaliseNumber(entry && entry.scale, 1);
+  const offset = normaliseNumber(entry && entry.offset, 0);
+  const rangeMin = entry && Object.prototype.hasOwnProperty.call(entry, 'rangeMin')
+    ? normaliseNumber(entry.rangeMin, null)
+    : null;
+  const rangeMax = entry && Object.prototype.hasOwnProperty.call(entry, 'rangeMax')
+    ? normaliseNumber(entry.rangeMax, null)
+    : null;
+  const bits = clampBits(entry && entry.bits);
+  return {
+    id,
+    name,
+    label,
+    input,
+    unit,
+    symbol,
+    enabled,
+    scale,
+    offset,
+    rangeMin,
+    rangeMax,
+    bits,
+  };
+}
+
+function nextDefaultId() {
+  let index = state.channels.length;
+  while (true) {
+    const candidate = `meter${index + 1}`;
+    const exists = state.channels.some((channel) => channel.id === candidate);
+    if (!exists) {
+      return candidate;
+    }
+    index += 1;
+  }
+}
+
+function createDefaultChannel() {
+  const id = nextDefaultId();
+  const baseInput = state.inputs.find((item) => item.active) || state.inputs[0];
+  return {
+    id,
+    name: id,
+    label: `Canal ${state.channels.length + 1}`,
+    input: baseInput ? baseInput.name : '',
+    unit: baseInput && baseInput.unit ? baseInput.unit : '',
+    symbol: '',
+    enabled: true,
+    scale: 1,
+    offset: 0,
+    rangeMin: null,
+    rangeMax: null,
+    bits: 10,
+  };
+}
+
+function updateCounter() {
+  const counter = document.getElementById('channelsCounter');
+  if (!counter) return;
+  const count = state.channels.length;
+  if (count === 0) {
+    counter.textContent = 'Aucun canal configuré';
+  } else if (count === 1) {
+    counter.textContent = '1 canal configuré';
+  } else {
+    counter.textContent = `${count} canaux configurés`;
+  }
+}
+
+function setStatus(message, type = '') {
+  const status = document.getElementById('statusMessage');
+  if (!status) return;
+  status.textContent = message || '';
+  status.classList.remove('error', 'success');
+  if (type) {
+    status.classList.add(type);
+  }
+}
+
+function handleInputSelection(select, channel, refreshSummary) {
+  select.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = '— Aucune entrée —';
+  select.appendChild(placeholder);
+  state.inputs.forEach((item) => {
+    const opt = document.createElement('option');
+    opt.value = item.name;
+    const unit = item.unit ? ` (${item.unit})` : '';
+    opt.textContent = `${item.name}${unit}`;
+    select.appendChild(opt);
+  });
+  select.value = channel.input || '';
+  select.addEventListener('change', (event) => {
+    channel.input = event.target.value.trim();
+    refreshSummary();
+  });
+}
+
+function createField(labelText, element) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'field';
+  const label = document.createElement('label');
+  label.textContent = labelText;
+  wrapper.append(label, element);
+  return wrapper;
+}
+
+function createNumberField(label, channel, key, options = {}) {
+  const input = document.createElement('input');
+  input.type = 'number';
+  if (options.step) input.step = options.step;
+  if (options.min !== undefined) input.min = options.min;
+  if (options.max !== undefined) input.max = options.max;
+  if (options.placeholder) input.placeholder = options.placeholder;
+  const value = channel[key];
+  input.value = value === null || value === undefined ? '' : value;
+  input.addEventListener('change', (event) => {
+    const raw = event.target.value.trim();
+    if (raw.length === 0 && options.allowNull) {
+      channel[key] = null;
+      event.target.value = '';
+      return;
+    }
+    const num = Number(raw);
+    if (!Number.isFinite(num)) {
+      if (options.allowNull) {
+        channel[key] = null;
+        event.target.value = '';
+      }
+      return;
+    }
+    let nextValue = num;
+    if (options.clamp) {
+      nextValue = Math.max(options.clamp.min, Math.min(options.clamp.max, nextValue));
+    }
+    if (options.round) {
+      nextValue = Math.round(nextValue);
+    }
+    channel[key] = nextValue;
+    event.target.value = nextValue;
+  });
+  return createField(label, input);
+}
+
+function createTextField(label, channel, key, refreshSummary) {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.value = channel[key] || '';
+  input.addEventListener('input', (event) => {
+    channel[key] = event.target.value.trim();
+    if (refreshSummary) {
+      refreshSummary();
+    }
+  });
+  return createField(label, input);
+}
+
+function createToggle(label, channel, key, refreshSummary) {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'toggle';
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = channel[key] !== false;
+  checkbox.addEventListener('change', (event) => {
+    channel[key] = !!event.target.checked;
+    if (refreshSummary) {
+      refreshSummary();
+    }
+  });
+  wrapper.append(checkbox, document.createTextNode(label));
+  return wrapper;
+}
+
+function renderChannels() {
+  const container = document.getElementById('channelsContainer');
+  const emptyState = document.getElementById('emptyState');
+  const addButton = document.getElementById('addChannelBtn');
+  if (!container) return;
+  container.innerHTML = '';
+  state.channels.forEach((channel, index) => {
+    const card = document.createElement('div');
+    card.className = 'channel-card';
+
+    const header = document.createElement('header');
+    const title = document.createElement('h2');
+    const subtitle = document.createElement('span');
+    const refreshSummary = () => {
+      const fallback = channel.id || `Canal ${index + 1}`;
+      title.textContent = channel.label || channel.name || fallback;
+      if (channel.input) {
+        subtitle.textContent = `Entrée assignée : ${channel.input}`;
+      } else {
+        subtitle.textContent = 'Aucune entrée assignée';
+      }
+    };
+    refreshSummary();
+    header.append(title, subtitle);
+    card.appendChild(header);
+
+    const firstRow = document.createElement('div');
+    firstRow.className = 'field-row';
+    firstRow.append(
+      createTextField('Identifiant (JSON)', channel, 'id', refreshSummary),
+      createTextField('Nom interne', channel, 'name', refreshSummary),
+      createTextField('Libellé affiché', channel, 'label', refreshSummary),
+    );
+    card.appendChild(firstRow);
+
+    const inputSelect = document.createElement('select');
+    handleInputSelection(inputSelect, channel, refreshSummary);
+    card.appendChild(createField('Entrée associée', inputSelect));
+
+    const secondRow = document.createElement('div');
+    secondRow.className = 'field-row';
+    secondRow.append(
+      createTextField('Unité', channel, 'unit'),
+      createTextField('Symbole', channel, 'symbol'),
+    );
+    card.appendChild(secondRow);
+
+    const thirdRow = document.createElement('div');
+    thirdRow.className = 'field-row';
+    thirdRow.append(
+      createNumberField('Échelle', channel, 'scale', { step: 'any' }),
+      createNumberField('Décalage', channel, 'offset', { step: 'any' }),
+    );
+    card.appendChild(thirdRow);
+
+    const fourthRow = document.createElement('div');
+    fourthRow.className = 'field-row';
+    fourthRow.append(
+      createNumberField('Plage min. (optionnelle)', channel, 'rangeMin', { step: 'any', allowNull: true, placeholder: '—' }),
+      createNumberField('Plage max. (optionnelle)', channel, 'rangeMax', { step: 'any', allowNull: true, placeholder: '—' }),
+    );
+    card.appendChild(fourthRow);
+
+    const fifthRow = document.createElement('div');
+    fifthRow.className = 'field-row';
+    fifthRow.append(
+      createNumberField('Résolution (bits)', channel, 'bits', {
+        min: 1,
+        max: 32,
+        clamp: { min: 1, max: 32 },
+        round: true,
+      }),
+    );
+    card.appendChild(fifthRow);
+
+    const toggleWrapper = document.createElement('div');
+    toggleWrapper.appendChild(createToggle('Activer ce canal', channel, 'enabled', refreshSummary));
+    card.appendChild(toggleWrapper);
+
+    const actions = document.createElement('div');
+    actions.className = 'card-actions';
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'remove';
+    removeBtn.textContent = 'Supprimer';
+    removeBtn.addEventListener('click', () => {
+      state.channels.splice(index, 1);
+      renderChannels();
+      updateCounter();
+      setStatus('Canal supprimé.', '');
+    });
+    actions.appendChild(removeBtn);
+    card.appendChild(actions);
+
+    container.appendChild(card);
+  });
+
+  if (emptyState) {
+    emptyState.hidden = state.channels.length > 0;
+  }
+  if (addButton) {
+    addButton.disabled = state.channels.length >= MAX_METER_CHANNELS;
+  }
+  updateCounter();
+}
+
+function serialiseChannels() {
+  return state.channels.map((channel, index) => {
+    const id = normaliseString(channel.id) || `meter${index + 1}`;
+    const name = normaliseString(channel.name) || id;
+    const label = normaliseString(channel.label) || name;
+    const input = normaliseString(channel.input);
+    const unit = normaliseString(channel.unit);
+    const symbol = normaliseString(channel.symbol);
+    const enabled = channel.enabled !== false;
+    const scale = Number.isFinite(channel.scale) ? channel.scale : 1;
+    const offset = Number.isFinite(channel.offset) ? channel.offset : 0;
+    const rangeMin = channel.rangeMin === null || channel.rangeMin === undefined
+      ? null
+      : Number(channel.rangeMin);
+    const rangeMax = channel.rangeMax === null || channel.rangeMax === undefined
+      ? null
+      : Number(channel.rangeMax);
+    const bits = clampBits(channel.bits);
+    return {
+      id,
+      name,
+      label,
+      input,
+      unit,
+      symbol,
+      enabled,
+      scale,
+      offset,
+      rangeMin,
+      rangeMax,
+      bits,
+    };
+  });
+}
+
+async function loadConfiguration() {
+  try {
+    await window.ensureSession?.();
+  } catch (err) {
+    setStatus('Authentification requise.', 'error');
+    return;
+  }
+  setStatus('Chargement de la configuration…');
+  try {
+    const response = await window.authFetch('/api/config/get');
+    if (!response.ok) {
+      throw new Error('HTTP ' + response.status);
+    }
+    const cfg = await response.json();
+    const inputs = Array.isArray(cfg.inputs) ? cfg.inputs : [];
+    state.inputs = inputs.map((entry) => ({
+      name: normaliseString(entry && entry.name),
+      unit: normaliseString(entry && entry.unit),
+      active: entry && entry.active !== false,
+    })).filter((item) => item.name.length > 0);
+    let channels = [];
+    if (cfg.virtualMultimeter && Array.isArray(cfg.virtualMultimeter.channels)) {
+      channels = cfg.virtualMultimeter.channels.map(normaliseChannel);
+    }
+    state.channels = channels;
+    renderChannels();
+    updateCounter();
+    setStatus('Configuration chargée.', 'success');
+  } catch (err) {
+    console.error('[VirtualLab] Impossible de charger la configuration', err);
+    setStatus('Impossible de charger la configuration.', 'error');
+  }
+}
+
+async function saveChannels() {
+  const saveBtn = document.getElementById('saveBtn');
+  const payload = {
+    channelCount: state.channels.length,
+    channels: serialiseChannels(),
+  };
+  try {
+    if (saveBtn) saveBtn.disabled = true;
+    setStatus('Sauvegarde en cours…');
+    const response = await window.authFetch('/api/config/virtual-multimeter', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const text = await response.text();
+    let data = null;
+    if (text && text.length) {
+      try {
+        data = JSON.parse(text);
+      } catch (err) {
+        data = null;
+      }
+    }
+    if (!response.ok) {
+      const message = data && data.error ? data.error : 'La sauvegarde a échoué.';
+      setStatus(message, 'error');
+      return;
+    }
+    if (data && data.applied && Array.isArray(data.applied.channels)) {
+      state.channels = data.applied.channels.map(normaliseChannel);
+      renderChannels();
+    }
+    setStatus('Canaux enregistrés avec succès.', 'success');
+  } catch (err) {
+    console.error('[VirtualLab] Sauvegarde impossible', err);
+    setStatus('Erreur réseau lors de la sauvegarde.', 'error');
+  } finally {
+    if (saveBtn) saveBtn.disabled = false;
+  }
+}
+
+function setupListeners() {
+  const addButton = document.getElementById('addChannelBtn');
+  if (addButton) {
+    addButton.addEventListener('click', () => {
+      if (state.channels.length >= MAX_METER_CHANNELS) {
+        setStatus(`Nombre maximal de canaux atteint (${MAX_METER_CHANNELS}).`, 'error');
+        return;
+      }
+      state.channels.push(createDefaultChannel());
+      renderChannels();
+      updateCounter();
+      setStatus('Nouveau canal ajouté.', '');
+    });
+  }
+  const saveBtn = document.getElementById('saveBtn');
+  if (saveBtn) {
+    saveBtn.addEventListener('click', saveChannels);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  setupListeners();
+  loadConfiguration();
+});

--- a/data/virtual-lab/settings.html
+++ b/data/virtual-lab/settings.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Virtual Lab — Configuration</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/style.css">
+  <style>
+    body {
+      font-family: "Segoe UI", Arial, sans-serif;
+      background: linear-gradient(135deg, rgba(10,109,216,0.08), rgba(69,209,255,0.06));
+      margin: 0;
+      min-height: 100vh;
+      color: #22324b;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      padding: 1.8em clamp(1.2em, 3vw, 2.2em) 1.2em;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5em;
+      background: rgba(255,255,255,0.92);
+      border-bottom: 1px solid rgba(10,109,216,0.1);
+      box-shadow: 0 8px 30px rgba(10,109,216,0.08);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.6em, 3vw, 2.1em);
+      font-weight: 700;
+      color: #0a3d91;
+    }
+    header a.primary-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4em;
+      padding: 0.55em 1.2em;
+      border-radius: 999px;
+      background: #0a6dd8;
+      color: #fff;
+      text-decoration: none;
+      font-weight: 600;
+      box-shadow: 0 10px 24px rgba(10,109,216,0.16);
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+    header a.primary-link:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 32px rgba(10,109,216,0.24);
+    }
+    main {
+      flex: 1;
+      padding: clamp(1.2em, 3vw, 2.4em);
+      max-width: 1100px;
+      margin: 0 auto;
+      width: 100%;
+      box-sizing: border-box;
+    }
+    .intro {
+      background: rgba(255,255,255,0.95);
+      border-radius: 16px;
+      padding: clamp(1.1em, 2.2vw, 1.8em);
+      box-shadow: 0 12px 32px rgba(10,109,216,0.08);
+      border: 1px solid rgba(10,109,216,0.12);
+      margin-bottom: 1.8em;
+    }
+    .intro p {
+      margin: 0.4em 0;
+      line-height: 1.5;
+      color: #31425e;
+    }
+    .channels-toolbar {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 1em;
+      align-items: center;
+      margin-bottom: 1em;
+    }
+    .channels-toolbar button {
+      background: #0a6dd8;
+      color: #fff;
+      border: none;
+      border-radius: 10px;
+      padding: 0.6em 1.4em;
+      font-size: 1em;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 10px 24px rgba(10,109,216,0.18);
+      transition: transform 0.12s ease, box-shadow 0.12s ease;
+    }
+    .channels-toolbar button:disabled {
+      background: #98bff0;
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
+    .channels-toolbar button:not(:disabled):hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 30px rgba(10,109,216,0.24);
+    }
+    .channel-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.2em;
+    }
+    .channel-card {
+      background: rgba(255,255,255,0.94);
+      border-radius: 14px;
+      padding: 1em 1.1em;
+      display: flex;
+      flex-direction: column;
+      gap: 0.8em;
+      border: 1px solid rgba(10,109,216,0.08);
+      box-shadow: 0 14px 28px rgba(10,109,216,0.08);
+      position: relative;
+    }
+    .channel-card header {
+      position: static;
+      background: none;
+      box-shadow: none;
+      padding: 0;
+      border: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.3em;
+    }
+    .channel-card header h2 {
+      margin: 0;
+      font-size: 1.1em;
+      color: #102c5c;
+    }
+    .channel-card header span {
+      font-size: 0.9em;
+      color: #4b5d7e;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.3em;
+    }
+    .field label {
+      font-weight: 600;
+      font-size: 0.92em;
+      color: #1d355d;
+    }
+    .field input,
+    .field select {
+      border-radius: 8px;
+      border: 1px solid rgba(15,71,169,0.2);
+      padding: 0.45em 0.55em;
+      font-size: 0.95em;
+      color: #1f2f4a;
+      background: rgba(255,255,255,0.95);
+    }
+    .field input:focus,
+    .field select:focus {
+      border-color: #0a6dd8;
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(10,109,216,0.18);
+    }
+    .field-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.8em;
+    }
+    .toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5em;
+      font-weight: 600;
+      color: #1d355d;
+    }
+    .card-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.6em;
+      margin-top: auto;
+    }
+    .card-actions button {
+      border-radius: 8px;
+      padding: 0.45em 0.9em;
+      border: none;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .card-actions button.remove {
+      background: #f04b4b;
+      color: white;
+      box-shadow: 0 6px 16px rgba(240,75,75,0.28);
+    }
+    .card-actions button.remove:hover {
+      filter: brightness(0.92);
+    }
+    .empty-state {
+      padding: 1.5em;
+      border-radius: 14px;
+      background: rgba(255,255,255,0.9);
+      border: 1px dashed rgba(10,109,216,0.3);
+      color: #3a4c6d;
+      text-align: center;
+    }
+    .status-bar {
+      margin-top: 2em;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1em;
+      align-items: center;
+      justify-content: space-between;
+      background: rgba(255,255,255,0.93);
+      padding: 0.9em 1.1em;
+      border-radius: 12px;
+      border: 1px solid rgba(10,109,216,0.1);
+      box-shadow: 0 12px 26px rgba(10,109,216,0.08);
+    }
+    .status-bar button {
+      background: #0a6dd8;
+      color: #fff;
+      border: none;
+      border-radius: 10px;
+      padding: 0.55em 1.4em;
+      font-size: 1em;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 10px 24px rgba(10,109,216,0.18);
+    }
+    .status-bar button:hover {
+      box-shadow: 0 14px 30px rgba(10,109,216,0.24);
+    }
+    .status-message {
+      font-size: 0.95em;
+      color: #31425e;
+    }
+    .status-message.error {
+      color: #c0392b;
+    }
+    .status-message.success {
+      color: #1f7a3d;
+    }
+    @media (max-width: 640px) {
+      .channels-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .status-bar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .status-bar button {
+        width: 100%;
+      }
+    }
+  </style>
+  <script src="../auth.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Configuration des appareils virtuels</h1>
+    <a class="primary-link" href="index.html">⬅ Retour au Virtual Lab</a>
+  </header>
+  <main>
+    <section class="intro">
+      <p>Définissez les canaux du multimètre virtuel en associant chaque voie à une entrée du MiniLabBox. Les réglages ci-dessous sont sauvegardés sans modifier le reste de la configuration matérielle.</p>
+      <p>Chaque canal peut appliquer une échelle, un décalage et optionnellement une plage numérique ou un symbole personnalisé pour l'affichage.</p>
+    </section>
+    <div class="channels-toolbar">
+      <button id="addChannelBtn" type="button">➕ Ajouter un canal</button>
+      <div id="channelsCounter">0 canal configuré</div>
+    </div>
+    <div id="channelsContainer" class="channel-grid" aria-live="polite"></div>
+    <div id="emptyState" class="empty-state" hidden>
+      Aucun canal configuré. Ajoutez une voie pour suivre les mesures du multimètre virtuel.
+    </div>
+    <div class="status-bar">
+      <button id="saveBtn" type="button">💾 Enregistrer les canaux</button>
+      <div id="statusMessage" class="status-message" role="status" aria-live="polite"></div>
+    </div>
+  </main>
+  <script type="module" src="js/settings.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove the virtual multimeter UI and logic from `data/config.html`, replacing it with a link to the new Virtual Lab settings page
- keep the firmware from clearing the saved multimeter channels when `/api/config/set` payloads omit the `virtualMultimeter` field

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7fec3d30832ea8ba7076e224be27