### PR TITLE
Increase JSON capacity for configuration saves

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ static const char *CONFIG_BACKUP_FILE_PATH = "/private/io_config.bak";
 static const char *CONFIG_TEMP_FILE_PATH = "/private/io_config.tmp";
 static const char *CONFIG_BACKUP_STAGING_PATH = "/private/io_config.bak.tmp";
 static const char *LEGACY_CONFIG_FILE_PATH = "/config.json";
-static const size_t CONFIG_JSON_CAPACITY = 12288;
+static const size_t CONFIG_JSON_CAPACITY = 16384;
 static const char SAMPLE_FILE_CONTENT[] = R"rawliteral(
 <!DOCTYPE html>
 <html lang="fr">
@@ -3074,7 +3074,7 @@ void registerRoutes(ServerT &server) {
       srv->send(400, "application/json", R"({"error":"No body"})");
       return;
     }
-    DynamicJsonDocument doc(4096);
+    DynamicJsonDocument doc(CONFIG_JSON_CAPACITY);
     if (deserializeJson(doc, body)) {
       srv->send(400, "application/json", R"({"error":"Invalid JSON"})");
       return;


### PR DESCRIPTION
## Summary
- bump CONFIG_JSON_CAPACITY to 16 KB so large configurations keep saving correctly
- reuse the same allocation when parsing virtual multimeter updates to avoid low-capacity failures

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8bd587a8832e9626023404d419b4