### PR TITLE
Separate IO save and reboot actions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2838,10 +2838,12 @@ static void handleIoConfigSetRequest(ServerT *srv, const String &body) {
   }
   logIoDelta(previousConfig, config);
   logConfigSummary("Applied IO");
-  logMessage("IO configuration update saved; rebooting");
+  logMessage("IO configuration update saved; reboot required");
   DynamicJsonDocument respDoc(2048);
   respDoc["status"] = "ok";
+  respDoc["saved"] = true;
   respDoc["verified"] = true;
+  respDoc["requiresReboot"] = true;
   JsonObject modulesObj = respDoc.createNestedObject("modules");
   modulesObj["ads1115"] = config.modules.ads1115;
   modulesObj["pwm010"] = config.modules.pwm010;
@@ -2893,8 +2895,6 @@ static void handleIoConfigSetRequest(ServerT *srv, const String &body) {
   String payload;
   serializeJson(respDoc, payload);
   srv->send(200, "application/json", payload);
-  delay(100);
-  ESP.restart();
 }
 
 template <typename ServerT>


### PR DESCRIPTION
## Summary
- avoid rebooting immediately after applying a new IO configuration
- include saved and requiresReboot flags in the IO configuration response so the UI can track persistence state

## Testing
- `pio run` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3c1d6c84832eb3ac2a8bf31d8d6d