### PR TITLE
Fix String payload creation to resolve compilation errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2101,7 +2101,7 @@ static bool loadConfigFromPath(const char *path,
   DeserializationError err = deserializeJson(doc, buf.get(), read);
   if (err) {
     String context = String(label) + " config";
-    String payload(buf.get(), read);
+    String payload(buf.get());
     logJsonParseFailure(context.c_str(), payload, docCapacity, err);
     return false;
   }
@@ -2777,8 +2777,8 @@ static bool verifyConfigStored(const Config &expected,
   DeserializationError err = deserializeJson(doc, buf.get());
   if (err) {
     errorDetail = String("json parse failed: ") + err.c_str();
-    String context = String(label) + " verify";
-    String payload(buf.get(), read);
+    String context = String(path) + " verify";
+    String payload(buf.get());
     logJsonParseFailure(context.c_str(), payload, docCapacity, err);
     return false;
   }


### PR DESCRIPTION
## Summary
- construct JSON payload strings from null-terminated buffers to match available Arduino String constructors
- log verification parse failures using the config path rather than an undefined label name

## Testing
- ⚠️ `pio run` *(platformio is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdca6f1160832eb427ea545ed07eb7