### PR TITLE
Refactor Virtual Lab multimeter interface

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -63,7 +63,7 @@
     <a class="virtual-lab-title" href="virtual-lab/index.html">
       Accéder au Virtual Lab professionnel
     </a>
-    <p>Un environnement immersif regroupant oscilloscope Tektronix, multimètre de laboratoire et générateur de fonctions.</p>
+    <p>Un environnement immersif regroupant oscilloscope virtuel, multimètre de laboratoire et générateur de fonctions.</p>
     <p>
       <a href="virtual-lab/settings.html">Configurer les appareils virtuels</a>
     </p>

--- a/data/virtual-lab/css/style.css
+++ b/data/virtual-lab/css/style.css
@@ -115,6 +115,45 @@ body {
   gap: 1.5rem;
 }
 
+.device-toolbar {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.device-config-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--text);
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.device-config-button:hover,
+.device-config-button:focus-visible {
+  background: rgba(74, 212, 255, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(32, 227, 255, 0.15);
+}
+
+.device-config-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.device-config-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
 .device-branding {
   display: flex;
   flex-direction: column;
@@ -148,6 +187,22 @@ body {
   gap: 0.35rem;
   align-items: flex-end;
   min-width: 180px;
+}
+
+@media (max-width: 720px) {
+  .device-toolbar {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .device-toolbar .io-selector {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .io-selector {
+    min-width: 0;
+  }
 }
 
 .io-selector label {
@@ -346,7 +401,7 @@ body {
 .multimeter-head {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-start;
   flex-wrap: wrap;
   gap: 1.6rem;
 }
@@ -478,48 +533,67 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.9rem;
 }
 
 .multimeter-gauge {
-  width: min(100%, 320px);
-  height: 120px;
+  width: min(100%, 360px);
+  height: 160px;
+}
+
+.multimeter-gauge-face {
+  fill: rgba(14, 40, 36, 0.9);
+  stroke: rgba(74, 212, 255, 0.18);
+  stroke-width: 2;
 }
 
 .multimeter-gauge-arc {
   fill: none;
-  stroke: rgba(125, 249, 169, 0.24);
-  stroke-width: 4;
+  stroke-width: 6;
   stroke-linecap: round;
+  filter: drop-shadow(0 6px 16px rgba(32, 227, 255, 0.25));
 }
 
 .multimeter-gauge-tick {
-  stroke: rgba(125, 249, 169, 0.5);
-  stroke-width: 2;
+  stroke: rgba(125, 249, 169, 0.65);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+}
+
+.multimeter-gauge-subtick {
+  stroke: rgba(125, 249, 169, 0.35);
+  stroke-width: 1.3;
   stroke-linecap: round;
 }
 
 .multimeter-gauge-needle {
-  stroke: #ff5c5c;
-  stroke-width: 3.6;
+  stroke: #ff7676;
+  stroke-width: 4.2;
   stroke-linecap: round;
   transition: stroke 0.2s ease;
+}
+
+.multimeter-gauge-cap {
+  fill: rgba(6, 24, 20, 0.92);
+  stroke: rgba(125, 249, 169, 0.35);
+  stroke-width: 3;
+  box-shadow: 0 0 12px rgba(125, 249, 169, 0.35);
 }
 
 .multimeter-gauge-labels {
   display: flex;
   justify-content: space-between;
-  width: min(100%, 320px);
+  width: min(100%, 360px);
   color: rgba(125, 249, 169, 0.75);
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   letter-spacing: 0.12em;
 }
 
 .multimeter-gauge-readout {
   font-family: "Segment7Standard", "Share Tech Mono", "Roboto Mono", monospace;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   color: #f6c65b;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.2em;
 }
 
 .multimeter-display progress::-webkit-progress-bar {

--- a/data/virtual-lab/index.html
+++ b/data/virtual-lab/index.html
@@ -22,12 +22,6 @@
     </section>
   </div>
 
-  <div style="text-align:center; margin: 1.5em 0;">
-    <a href="settings.html" style="display:inline-flex; align-items:center; gap:0.4em; padding:0.6em 1.2em; border-radius:999px; background:#0a6dd8; color:#fff; text-decoration:none; font-weight:600; box-shadow:0 12px 28px rgba(10,109,216,0.18);">
-      ⚙️ Configurer les appareils virtuels
-    </a>
-  </div>
-
   <noscript>
     <div class="noscript">Activez JavaScript pour accéder au laboratoire virtuel.</div>
   </noscript>

--- a/data/virtual-lab/js/functionGenerator.js
+++ b/data/virtual-lab/js/functionGenerator.js
@@ -89,13 +89,18 @@ export function mountFunctionGenerator(container, { outputs = [], error = null }
     <div class="device-shell generator-shell">
       <div class="device-header">
         <div class="device-branding">
-          <span class="device-brand">Rigol</span>
-          <span class="device-model" id="function-generator-title">DG1022Z</span>
-          <span class="device-subtitle">Générateur de fonctions</span>
+          <span class="device-brand">MiniLabBox</span>
+          <span class="device-model" id="function-generator-title">Générateur virtuel</span>
+          <span class="device-subtitle">Création de signaux</span>
         </div>
-        <div class="io-selector">
-          <label for="function-io">Sortie assignée</label>
-          <select id="function-io" class="io-select"></select>
+        <div class="device-toolbar">
+          <a class="device-config-button" href="settings.html#generator" aria-label="Configurer le générateur de fonctions virtuel">
+            ⚙️ Configurer
+          </a>
+          <div class="io-selector">
+            <label for="function-io">Sortie assignée</label>
+            <select id="function-io" class="io-select"></select>
+          </div>
         </div>
       </div>
       <div class="device-status" id="function-generator-status"></div>

--- a/data/virtual-lab/js/ioCatalog.js
+++ b/data/virtual-lab/js/ioCatalog.js
@@ -37,6 +37,10 @@ function normaliseMeterChannel(entry, index, inputsByName) {
   const label = typeof entry.label === 'string' && entry.label.trim().length
     ? entry.label.trim()
     : idSource;
+  const profile = typeof entry.profile === 'string' ? entry.profile.trim() : '';
+  const displayMode = typeof entry.displayMode === 'string' ? entry.displayMode.trim() : '';
+  const calibre = typeof entry.calibre === 'string' ? entry.calibre.trim() : '';
+  const processing = typeof entry.processing === 'string' ? entry.processing : '';
   const baseInput = inputsByName.get(inputName);
   return {
     id: idSource,
@@ -50,7 +54,11 @@ function normaliseMeterChannel(entry, index, inputsByName) {
     offset: Number.isFinite(offset) ? offset : 0,
     rangeMin: Number.isFinite(rangeMin) ? rangeMin : null,
     rangeMax: Number.isFinite(rangeMax) ? rangeMax : null,
-    bits
+    bits,
+    profile,
+    displayMode,
+    calibre,
+    processing
   };
 }
 

--- a/data/virtual-lab/js/mathZone.js
+++ b/data/virtual-lab/js/mathZone.js
@@ -25,9 +25,14 @@ export function mountMathZone(container) {
     <div class="device-shell math-shell">
       <div class="device-header">
         <div class="device-branding">
-          <span class="device-brand">Analyse</span>
+          <span class="device-brand">MiniLabBox</span>
           <span class="device-model" id="math-zone-title">Console mathématique</span>
           <span class="device-subtitle">Calculs temps réel</span>
+        </div>
+        <div class="device-toolbar">
+          <a class="device-config-button" href="settings.html#math" aria-label="Configurer la console mathématique">
+            ⚙️ Configurer
+          </a>
         </div>
       </div>
       <div class="math-console">

--- a/data/virtual-lab/js/oscilloscope.js
+++ b/data/virtual-lab/js/oscilloscope.js
@@ -90,13 +90,18 @@ export function mountOscilloscope(container, { inputs = [], error = null } = {})
     <div class="device-shell oscilloscope-shell">
       <div class="device-header">
         <div class="device-branding">
-          <span class="device-brand">Tektronix</span>
-          <span class="device-model" id="oscilloscope-title">Série 3 MSO</span>
-          <span class="device-subtitle">Oscilloscope numérique quatre voies</span>
+          <span class="device-brand">MiniLabBox</span>
+          <span class="device-model" id="oscilloscope-title">Oscilloscope virtuel</span>
+          <span class="device-subtitle">Analyse temps réel</span>
         </div>
-        <div class="io-selector">
-          <label for="oscilloscope-channel">Entrée active</label>
-          <select id="oscilloscope-channel" class="io-select"></select>
+        <div class="device-toolbar">
+          <a class="device-config-button" href="settings.html#oscilloscope" aria-label="Configurer l'oscilloscope virtuel">
+            ⚙️ Configurer
+          </a>
+          <div class="io-selector">
+            <label for="oscilloscope-channel">Entrée active</label>
+            <select id="oscilloscope-channel" class="io-select"></select>
+          </div>
         </div>
       </div>
       <div class="device-status" id="oscilloscope-status"></div>

--- a/data/virtual-lab/settings.html
+++ b/data/virtual-lab/settings.html
@@ -72,6 +72,49 @@
       line-height: 1.5;
       color: #31425e;
     }
+    .settings-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8em;
+      margin: 0 0 1.8em;
+    }
+    .settings-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3em;
+      padding: 0.45em 0.95em;
+      border-radius: 999px;
+      background: rgba(10,109,216,0.12);
+      color: #0a3d91;
+      text-decoration: none;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    }
+    .settings-nav a:hover {
+      background: rgba(10,109,216,0.2);
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px rgba(10,109,216,0.16);
+    }
+    .device-config-section {
+      background: rgba(255,255,255,0.94);
+      border-radius: 16px;
+      padding: clamp(1.1em, 2.5vw, 1.8em);
+      box-shadow: 0 12px 28px rgba(10,109,216,0.08);
+      border: 1px solid rgba(10,109,216,0.1);
+      margin-bottom: 2.4em;
+    }
+    .device-config-section:last-of-type {
+      margin-bottom: 0;
+    }
+    .device-config-section h2 {
+      margin-top: 0;
+      color: #0a3d91;
+    }
+    .device-config-section p {
+      color: #31425e;
+      line-height: 1.5;
+    }
     .channels-toolbar {
       display: flex;
       justify-content: space-between;
@@ -148,7 +191,8 @@
       color: #1d355d;
     }
     .field input,
-    .field select {
+    .field select,
+    .field textarea {
       border-radius: 8px;
       border: 1px solid rgba(15,71,169,0.2);
       padding: 0.45em 0.55em;
@@ -157,10 +201,16 @@
       background: rgba(255,255,255,0.95);
     }
     .field input:focus,
-    .field select:focus {
+    .field select:focus,
+    .field textarea:focus {
       border-color: #0a6dd8;
       outline: none;
       box-shadow: 0 0 0 3px rgba(10,109,216,0.18);
+    }
+    .field textarea {
+      min-height: 130px;
+      resize: vertical;
+      font-family: "Roboto Mono", "Fira Code", "Courier New", monospace;
     }
     .field-row {
       display: grid;
@@ -264,20 +314,46 @@
   <main>
     <section class="intro">
       <p>Définissez les canaux du multimètre virtuel en associant chaque voie à une entrée du MiniLabBox. Les réglages ci-dessous sont sauvegardés sans modifier le reste de la configuration matérielle.</p>
-      <p>Chaque canal peut appliquer une échelle, un décalage et optionnellement une plage numérique ou un symbole personnalisé pour l'affichage.</p>
+      <p>Chaque canal peut appliquer une échelle, un décalage et une logique de mesure personnalisée pour convertir la lecture brute en valeur exploitable.</p>
     </section>
-    <div class="channels-toolbar">
-      <button id="addChannelBtn" type="button">➕ Ajouter un canal</button>
-      <div id="channelsCounter">0 canal configuré</div>
-    </div>
-    <div id="channelsContainer" class="channel-grid" aria-live="polite"></div>
-    <div id="emptyState" class="empty-state" hidden>
-      Aucun canal configuré. Ajoutez une voie pour suivre les mesures du multimètre virtuel.
-    </div>
-    <div class="status-bar">
-      <button id="saveBtn" type="button">💾 Enregistrer les canaux</button>
-      <div id="statusMessage" class="status-message" role="status" aria-live="polite"></div>
-    </div>
+    <nav class="settings-nav" aria-label="Navigation configuration">
+      <a href="#multimeter">⚡ Multimètre</a>
+      <a href="#oscilloscope">📈 Oscilloscope</a>
+      <a href="#generator">🎛️ Générateur</a>
+      <a href="#math">∑ Console math</a>
+    </nav>
+
+    <section id="multimeter" class="device-config-section">
+      <h2>Multimètre virtuel</h2>
+      <p>Associez chaque canal à une entrée matérielle et définissez la logique de conversion utilisée par le cadran numérique.</p>
+      <div class="channels-toolbar">
+        <button id="addChannelBtn" type="button">➕ Ajouter un canal</button>
+        <div id="channelsCounter">0 canal configuré</div>
+      </div>
+      <div id="channelsContainer" class="channel-grid" aria-live="polite"></div>
+      <div id="emptyState" class="empty-state" hidden>
+        Aucun canal configuré. Ajoutez une voie et précisez la logique de mesure du multimètre virtuel.
+      </div>
+      <div class="status-bar">
+        <button id="saveBtn" type="button">💾 Enregistrer les canaux</button>
+        <div id="statusMessage" class="status-message" role="status" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section id="oscilloscope" class="device-config-section">
+      <h2>Oscilloscope virtuel</h2>
+      <p>L'oscilloscope s'appuie directement sur les entrées actives de la MiniLabBox. Activez ou désactivez les voies analogiques depuis la configuration générale pour les retrouver dans le Virtual Lab.</p>
+    </section>
+
+    <section id="generator" class="device-config-section">
+      <h2>Générateur de fonctions virtuel</h2>
+      <p>Le générateur propose toutes les sorties actives. Les paramètres détaillés (forme d'onde, amplitude, offset) se règlent directement sur l'appareil virtuel.</p>
+    </section>
+
+    <section id="math" class="device-config-section">
+      <h2>Console mathématique</h2>
+      <p>Aucun réglage spécifique n'est requis pour la console mathématique : elle exécute les expressions que vous saisissez dans l'interface du Virtual Lab.</p>
+    </section>
   </main>
   <script type="module" src="js/settings.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- redesign the Virtual Lab multimeter with a new analog gauge, selectable display modes, and a scriptable processing pipeline tied to channel selection and overrides
- surface multimeter channel preferences from configuration (profile, display mode, calibre, processing script) and expose matching controls on the settings page with refreshed layout and defaults
- unify Virtual Lab device headers with MiniLabBox branding and inline configuration buttons while removing legacy Tektronix references and the central config link

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce83b379c0832e96285a6976d64e8d