### PR TITLE
Simplify input form and redesign multimeter channel configuration

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -145,14 +145,14 @@
         <label for="modalType">Type</label>
         <select id="modalType"></select>
       </div>
-      <div class="modal-form-row">
+      <div class="modal-form-row" id="modalActiveRow">
         <label class="toggle"><input type="checkbox" id="modalActive"> Activer cette voie</label>
       </div>
-      <div class="modal-form-row">
+      <div class="modal-form-row" id="modalScaleRow">
         <label for="modalScale">Échelle</label>
         <input type="number" step="any" id="modalScale">
       </div>
-      <div class="modal-form-row">
+      <div class="modal-form-row" id="modalOffsetRow">
         <label for="modalOffset">Décalage</label>
         <input type="number" step="any" id="modalOffset">
       </div>
@@ -650,7 +650,7 @@ function availablePinsForInput(data, index) {
   if (!ANALOG_TYPES.has(data.type)) {
     return [];
   }
-  const basePins = Array.from(new Set([...ANALOG_PINS, ...DIGITAL_PINS]));
+  const basePins = Array.from(new Set([...ANALOG_PINS]));
   const used = gatherUsedPins('input', ANALOG_TYPES, index);
   return basePins.filter(pin => !used.has(pin) || data.pin === pin);
 }
@@ -1174,7 +1174,7 @@ function renderTypeSpecificFields(data, kind) {
       const row = document.createElement('div');
       row.className = 'modal-form-row';
       const label = document.createElement('label');
-      label.textContent = 'Entrée analogique';
+      label.textContent = 'PIN';
       const select = document.createElement('select');
       const availablePins = availablePinsForInput(data, modalState ? modalState.index : -1);
       if (!data.pin || !availablePins.includes(data.pin)) {
@@ -1350,12 +1350,15 @@ function renderModalForm() {
   const description = document.getElementById('modalDescription');
   const nameInput = document.getElementById('modalName');
   const typeSelect = document.getElementById('modalType');
+  const activeRow = document.getElementById('modalActiveRow');
+  const scaleRow = document.getElementById('modalScaleRow');
+  const offsetRow = document.getElementById('modalOffsetRow');
   const activeCheckbox = document.getElementById('modalActive');
   const scaleInput = document.getElementById('modalScale');
   const offsetInput = document.getElementById('modalOffset');
   const unitRow = document.getElementById('modalUnitRow');
   const unitInput = document.getElementById('modalUnit');
-  if (!title || !description || !nameInput || !typeSelect || !activeCheckbox || !scaleInput || !offsetInput || !unitRow || !unitInput) {
+  if (!title || !description || !nameInput || !typeSelect || !activeRow || !scaleRow || !offsetRow || !activeCheckbox || !scaleInput || !offsetInput || !unitRow || !unitInput) {
     return;
   }
   title.textContent = index != null ? (kind === 'input' ? 'Modifier une entrée' : 'Modifier une sortie')
@@ -1370,6 +1373,13 @@ function renderModalForm() {
   };
   typeSelect.innerHTML = '';
   let options = typeOptionsForKind(kind);
+  const isNewInput = kind === 'input' && index == null;
+  if (isNewInput) {
+    options = options.filter(opt => opt.value === 'adc');
+    if (data.type !== 'adc') {
+      data.type = 'adc';
+    }
+  }
   if (!options.length) {
     options = [{ value: 'disabled', label: 'Désactivée' }];
   }
@@ -1388,6 +1398,7 @@ function renderModalForm() {
     data.type = options[0].value;
   }
   typeSelect.value = data.type;
+  typeSelect.disabled = isNewInput;
   typeSelect.onchange = (ev) => {
     applyTypeChange(kind, ev.target.value);
     renderModalForm();
@@ -1407,12 +1418,29 @@ function renderModalForm() {
     modalState.data.offset = Number.isFinite(value) ? value : 0;
   };
   if (kind === 'input') {
-    unitRow.classList.remove('hidden');
-    unitInput.value = data.unit || '';
-    unitInput.oninput = (ev) => {
-      modalState.data.unit = ev.target.value;
-    };
+    if (isNewInput) {
+      activeRow.classList.add('hidden');
+      scaleRow.classList.add('hidden');
+      offsetRow.classList.add('hidden');
+      unitRow.classList.add('hidden');
+      modalState.data.active = true;
+      modalState.data.scale = 1;
+      modalState.data.offset = 0;
+      modalState.data.unit = '';
+    } else {
+      activeRow.classList.remove('hidden');
+      scaleRow.classList.remove('hidden');
+      offsetRow.classList.remove('hidden');
+      unitRow.classList.remove('hidden');
+      unitInput.value = data.unit || '';
+      unitInput.oninput = (ev) => {
+        modalState.data.unit = ev.target.value;
+      };
+    }
   } else {
+    activeRow.classList.remove('hidden');
+    scaleRow.classList.remove('hidden');
+    offsetRow.classList.remove('hidden');
     unitRow.classList.add('hidden');
   }
   renderTypeSpecificFields(modalState.data, kind);

--- a/data/virtual-lab/settings.html
+++ b/data/virtual-lab/settings.html
@@ -322,6 +322,67 @@
     .card-actions button.remove:hover {
       filter: brightness(0.92);
     }
+    .measurement-grid {
+      display: grid;
+      gap: 0.75em;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      margin-top: 0.8em;
+    }
+    .measurement-card {
+      border: 1px solid rgba(10,109,216,0.15);
+      border-radius: 10px;
+      padding: 0.75em 0.9em;
+      background: rgba(255,255,255,0.95);
+      box-shadow: 0 8px 20px rgba(10,109,216,0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 0.6em;
+    }
+    .measurement-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.6em;
+    }
+    .measurement-card-header h3 {
+      margin: 0;
+      font-size: 1.05em;
+      color: #1d355d;
+    }
+    .measurement-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4em;
+      font-weight: 600;
+      color: #1d355d;
+    }
+    .measurement-range {
+      display: grid;
+      gap: 0.5em;
+      grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    }
+    .measurement-range label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35em;
+      font-weight: 600;
+      color: #3a4c6d;
+    }
+    .measurement-formula-label {
+      font-weight: 600;
+      color: #1d355d;
+    }
+    .measurement-formula {
+      width: 100%;
+      min-height: 96px;
+      resize: vertical;
+      font-family: 'Fira Code', 'Menlo', 'Consolas', monospace;
+      border: 1px solid rgba(10,109,216,0.2);
+      border-radius: 8px;
+      background: rgba(255,255,255,0.92);
+      padding: 0.5em 0.6em;
+      color: #1d355d;
+    }
     .empty-state {
       padding: 1.5em;
       border-radius: 14px;


### PR DESCRIPTION
## Summary
- constrain the input creation modal to the required name/type/pin fields with ADC defaults
- rebuild the virtual multimeter channel interface around per-measurement activation, ranges and formulas with updated styling
- extend the firmware configuration schema to persist the per-measurement settings emitted by the new UI

## Testing
- `pio run` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb20c063c832eaaeefb32cf336445