### PR TITLE
Mark IO entries as synced after successful save

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -793,6 +793,11 @@ function resetSnapshotsFromConfig(kind, list) {
   });
 }
 
+function markAllSnapshotsSaved() {
+  resetSnapshotsFromConfig('input', inputs);
+  resetSnapshotsFromConfig('output', outputs);
+}
+
 function applyServerSnapshots(kind, entries) {
   const map = getSnapshotMap(kind);
   map.clear();
@@ -1631,6 +1636,11 @@ async function saveConfig() {
     if (statusEl) {
       statusEl.textContent = 'Fichier enregistré.';
     }
+    markAllSnapshotsSaved();
+    logIoStep('Configuration IO sauvegardée côté serveur', {
+      inputs: inputs.length,
+      outputs: outputs.length
+    });
   } catch (err) {
     console.error(err);
     if (statusEl) {


### PR DESCRIPTION
## Summary
- add a helper that refreshes the IO snapshot map with the current configuration
- call the helper after a successful POST so the UI shows entries as synchronised
- log the successful save to the IO configuration journal

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf12ce6b7c832ea0b2c416d90f8725