### PR TITLE
Improve robustness of file save endpoints

### DIFF
--- a/data/editor.html
+++ b/data/editor.html
@@ -80,6 +80,8 @@
         'delete failed': 'Suppression impossible.',
         'rename failed': 'Impossible de renommer le fichier.',
         'create failed': 'Impossible de créer le fichier.',
+        'write failed': 'Impossible d\'écrire le fichier.',
+        'payload_too_large': 'Le fichier est trop volumineux pour être enregistré.',
         'missing path': 'Chemin de fichier manquant.',
         'No body': 'Requête invalide.',
         'Invalid JSON': 'JSON invalide.',


### PR DESCRIPTION
## Summary
- grow the JSON document capacity dynamically when saving or creating files so large payloads no longer fail to parse
- reuse the shared LittleFS write helper and clean up on failure, returning explicit errors for write failures and oversized payloads
- surface the new error codes in the web editor so users receive meaningful feedback

## Testing
- Not run (PlatformIO CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf1816eea0832eaff7b646235290f9