### PR TITLE
Fix missing forward declarations for user path helpers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,9 @@
 static void logPrintf(const char *fmt, ...);
 static void logMessage(const String &msg);
 
+static bool ensureUserDirectory();
+static String toRelativeUserPath(const String &fsPath);
+
 static bool logStorageReady = false;
 static bool littleFsFormatAttempted = false;
 static String firmwareVersion = "0.0.0";
@@ -2148,8 +2151,6 @@ static String diffInputConfig(const InputConfig &before, const InputConfig &afte
 static String diffOutputConfig(const OutputConfig &before, const OutputConfig &after);
 static const char *describeJsonType(const JsonVariantConst &value);
 static void logIoDelta(const Config &before, const Config &after);
-static bool ensureUserDirectory();
-static String toRelativeUserPath(const String &fsPath);
 static bool verifyConfigStored(const Config &expected,
                                const char *path,
                                uint8_t sections,


### PR DESCRIPTION
## Summary
- add forward declarations for ensureUserDirectory and toRelativeUserPath near the top of main.cpp so they are visible at first use
- remove the duplicate declarations from the later forward declaration block

## Testing
- not run (platformio CLI not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d08357f390832eb30f1a53b3995ebe