### PR TITLE
Fix virtual multimeter config build issues

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1558,6 +1558,10 @@ static String describePinValue(int pin);
 static String describeOptionalInt(int value);
 static uint8_t parseI2cAddress(const String &s);
 static String formatI2cAddress(uint8_t address);
+static bool virtualMultimeterConfigsMatch(
+    const VirtualMultimeterConfig &expected,
+    const VirtualMultimeterConfig &actual,
+    String &errorDetail);
 
 // ---------------------------------------------------------------------------
 // Helper utilities for robust IO configuration parsing.
@@ -3653,8 +3657,9 @@ bool saveVirtualConfig() {
   JsonObject meterObj =
       virtualMultimeterStorageDoc.createNestedObject("virtualMultimeter");
   populateVirtualMultimeterJson(meterObj, config.virtualMultimeter);
-  if (virtualMultimeterSaveBuffer.capacity() < VIRTUAL_MULTIMETER_MAX_PAYLOAD) {
-    virtualMultimeterSaveBuffer.reserve(VIRTUAL_MULTIMETER_MAX_PAYLOAD);
+  if (!virtualMultimeterSaveBuffer.reserve(VIRTUAL_MULTIMETER_MAX_PAYLOAD)) {
+    logMessage(String(label) + " buffer allocation failed");
+    return false;
   }
   virtualMultimeterSaveBuffer = "";
   if (serializeJson(virtualMultimeterStorageDoc, virtualMultimeterSaveBuffer) ==


### PR DESCRIPTION
## Summary
- add a forward declaration for virtual multimeter config comparison helpers so earlier code can reference them
- guard virtual multimeter saves by reserving the payload buffer and reporting allocation failures instead of touching the protected capacity() API

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19ebf0f20832e82a3a68d03a9135d