### PR TITLE
Add forward declarations for hardware reinit helpers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,13 @@ static bool scheduleRestart(const String &reason);
 static bool scheduleRestart(const __FlashStringHelper *reason);
 static bool scheduleRestart(const char *reason);
 
+// Forward declarations for hardware lifecycle helpers defined later in the
+// file.  serviceRestartGuard() invokes these when leaving safe mode, so the
+// compiler needs to know about them before their definitions.
+void setupSensors();
+void updateOutputs();
+void updateInputs();
+
 static void updateSafeModeStateFromGuard();
 static const char *safeModeReasonKey(SafeModeReason reason);
 static const char *safeModeReasonDescription(SafeModeReason reason);


### PR DESCRIPTION
## Summary
- add forward declarations for the hardware setup/update helpers that serviceRestartGuard uses
- ensure serviceRestartGuard can invoke the helpers when leaving safe mode without missing symbol errors

## Testing
- `pio run` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bcf2e95c832eb8435d2d260cfa94