### PR TITLE
Feed watchdog while computing configuration CRC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3800,6 +3800,11 @@ static uint32_t crc32ForBuffer(const uint8_t *data, size_t length) {
         crc >>= 1;
       }
     }
+    if ((i & 0x3FF) == 0) {
+      // Feeding the watchdog while computing checksums prevents boot loops
+      // when processing large configuration files.
+      yield();
+    }
   }
   return crc ^ 0xFFFFFFFFu;
 }


### PR DESCRIPTION
## Summary
- add periodic watchdog yields when computing CRC32 checksums for configuration payloads to avoid long blocking loops

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1c23a69d0832e82d6bf722c2a59eb